### PR TITLE
Extract AppHelper, avoid RedisClient test failure on start

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,4 +28,5 @@ function assembleApp(redirectDb, app) {
   app.put('/', function(req, res) {
   })
   */
+  return app
 }

--- a/tests/assemble-app-test.js
+++ b/tests/assemble-app-test.js
@@ -2,7 +2,7 @@
 
 var assembleApp = require('../lib').assembleApp
 var RedirectDb = require('../lib/redirect-db')
-var http = require('http')
+var AppHelper = require('./helpers/app-helper')
 var express = require('express')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
@@ -12,14 +12,11 @@ chai.should()
 chai.use(chaiAsPromised)
 
 describe('assembleApp', function() {
-  var redirectDb, getRedirect, expressApp, server, port, sendRequest
+  var redirectDb, getRedirect, app
 
   before(function() {
     redirectDb = new RedirectDb
-    expressApp = express()
-    assembleApp(redirectDb, expressApp)
-    server = http.createServer(expressApp).listen(0)
-    port = server.address().port
+    app = new AppHelper(assembleApp(redirectDb, express()))
   })
 
   beforeEach(function() {
@@ -30,58 +27,24 @@ describe('assembleApp', function() {
     getRedirect.restore()
   })
 
-  sendRequest = function(method, url) {
-    return new Promise(function(resolve, reject) {
-      var options = {
-            protocol: 'http:',
-            host:     'localhost',
-            port:     port,
-            path:     url,
-            method:   method
-          },
-          req
-
-      req = http.request(options, function(res) {
-        var result = ''
-
-        res.setEncoding('utf8')
-        res.on('data', function(chunk) {
-          result += chunk
-        })
-        res.on('end', function() {
-          if (res.statusCode === 200) {
-            resolve(result)
-          } else if (res.statusCode === 302) {
-            resolve(res.headers['location'] || 'Location missing')
-          } else {
-            reject(new Error(res.statusCode + ': ' + result))
-          }
-        })
-      })
-      req.on('error', function(err) {
-        reject(new Error('Unexpected HTTP error: ' + err.message))
-      })
-      req.end()
-    })
-  }
-
   it('returns the index page', function() {
-    return sendRequest('GET', '/').should.be.fulfilled.then(function(result) {
-      result.match('Url Pointers').should.exist
-    })
+    return app.sendRequest('GET', '/')
+      .should.be.fulfilled.then(function(result) {
+        result.match('Url Pointers').should.exist
+      })
   })
 
   it('redirects to the url returned by the RedirectDb', function() {
     var redirectLocation = 'https://mike-bland.com/'
     getRedirect.withArgs('/foo').returns(Promise.resolve(redirectLocation))
-    return sendRequest('GET', '/foo').should.become(redirectLocation)
+    return app.sendRequest('GET', '/foo').should.become(redirectLocation)
   })
 
   it('reports an error', function() {
     getRedirect.withArgs('/foo').callsFake(function() {
       return Promise.reject('forced error')
     })
-    return sendRequest('GET', '/foo').should.be.rejectedWith(Error, 
+    return app.sendRequest('GET', '/foo').should.be.rejectedWith(Error,
       '500: Error while processing /foo: forced error')
   })
 })

--- a/tests/helpers/app-helper.js
+++ b/tests/helpers/app-helper.js
@@ -1,0 +1,47 @@
+'use strict'
+
+var http = require('http')
+
+module.exports = AppHelper
+
+function AppHelper(app) {
+  this.server = http.createServer(app).listen(0)
+  this.port = this.server.address().port
+}
+
+AppHelper.prototype.sendRequest = function(method, url) {
+  var port = this.port
+
+  return new Promise(function(resolve, reject) {
+    var options = {
+          protocol: 'http:',
+          host:     'localhost',
+          port:     port,
+          path:     url,
+          method:   method
+        },
+        req
+
+    req = http.request(options, function(res) {
+      var result = ''
+
+      res.setEncoding('utf8')
+      res.on('data', function(chunk) {
+        result += chunk
+      })
+      res.on('end', function() {
+        if (res.statusCode === 200) {
+          resolve(result)
+        } else if (res.statusCode === 302) {
+          resolve(res.headers['location'] || 'Location missing')
+        } else {
+          reject(new Error(res.statusCode + ': ' + result))
+        }
+      })
+    })
+    req.on('error', function(err) {
+      reject(new Error('Unexpected HTTP error: ' + err.message))
+    })
+    req.end()
+  })
+}

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -20,9 +20,12 @@ module.exports = {
 
   launchRedis: function(port) {
     return new Promise(function(resolve, reject) {
-      var redisServer = spawn('redis-server',
-            ['--port', port, '--save', '', '--appendonly', 'no']),
+      var redisServer,
           stdout = ''
+
+      redisServer = spawn('redis-server',
+        ['--port', port, '--save', '', '--appendonly', 'no',
+          '--dbfilename', 'some-nonexistent-file.db'])
 
       redisServer.stdout.on('data', function(data) {
         stdout += data


### PR DESCRIPTION
Makes assemble-app-test.js easier to read in preparation for testing more API methods.

Also, the 'returns null if a redirect doesn't exist' case was failing if there was a nonempty `dump.rdb` file from a separate redis-server run that contained relocation data for `/foo`. Since there doesn't appear to be a redis-server flag to instruct redis not to load the dump file, specifying a nonexistent dump file resolves this issue.