### PR TITLE
RedirectDb: Make recordAccess an option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ function assembleApp(app, redirectDb, logger) {
   app.use(express.static(path.join(__dirname, '..', 'public')))
 
   app.get('/*', function(req, res) {
-    redirectDb.getRedirect(req.path)
+    redirectDb.getRedirect(req.path, { recordAccess: true })
       .then(function(urlData) {
         res.redirect(urlData !== null ? urlData.location : '/?url=' + req.path)
       })

--- a/lib/redirect-db.js
+++ b/lib/redirect-db.js
@@ -7,10 +7,11 @@ function RedirectDb(client, logger) {
   this.logger = logger
 }
 
-RedirectDb.prototype.getRedirect = function(url) {
+RedirectDb.prototype.getRedirect = function(url, options) {
   var db = this
+  options = options || {}
   return this.client.getRedirect(url).then(function(urlData) {
-    if (urlData !== null) {
+    if (urlData !== null && options.recordAccess) {
       db.client.recordAccess(url).catch(function(err) {
         db.logger.error('failed to record access for ' + url + ': ' + err)
       })

--- a/tests/app-test.js
+++ b/tests/app-test.js
@@ -41,22 +41,25 @@ describe('assembleApp', function() {
 
     it('redirects to the url returned by the RedirectDb', function() {
       var redirectLocation = 'https://mike-bland.com/'
-      getRedirect.withArgs('/foo').returns(Promise.resolve(
-        { location: redirectLocation, owner: 'mbland', count: 27 }))
+      getRedirect.withArgs('/foo', { recordAccess: true })
+        .returns(Promise.resolve(
+          { location: redirectLocation, owner: 'mbland', count: 27 }))
       return app.sendRequest('GET', '/foo').should.become(redirectLocation)
     })
 
     it('redirects to the homepage with nonexistent url parameter', function() {
-      getRedirect.withArgs('/foo').returns(Promise.resolve(null))
+      getRedirect.withArgs('/foo', { recordAccess: true })
+        .returns(Promise.resolve(null))
       return app.sendRequest('GET', '/foo').should.become('/?url=/foo')
     })
 
     it('reports an error', function() {
       var logError = sinon.spy(logger, 'error')
 
-      getRedirect.withArgs('/foo').callsFake(function() {
-        return Promise.reject(new Error('forced error'))
-      })
+      getRedirect.withArgs('/foo', { recordAccess: true })
+        .callsFake(function() {
+          return Promise.reject(new Error('forced error'))
+        })
       return app.sendRequest('GET', '/foo')
         .should.be.rejectedWith(Error,
           '500: Error while processing /foo: Error: forced error')

--- a/tests/redirect-db-test.js
+++ b/tests/redirect-db-test.js
@@ -46,7 +46,26 @@ describe('RedirectDb', function() {
 
       stubClientMethod('getRedirect').withArgs('/foo')
         .returns(Promise.resolve(urlData))
+      stubClientMethod('recordAccess').withArgs('/foo')
+        .returns(Promise.resolve())
       return redirectDb.getRedirect('/foo').should.become(urlData)
+        .then(function() {
+          client.recordAccess.calledOnce.should.be.false
+        })
+    })
+
+    it('records access of a known URL', function() {
+      var urlData = { location: REDIRECT_TARGET, owner: 'mbland', count: 27 }
+
+      stubClientMethod('getRedirect').withArgs('/foo')
+        .returns(Promise.resolve(urlData))
+      stubClientMethod('recordAccess').withArgs('/foo')
+        .returns(Promise.resolve())
+      return redirectDb.getRedirect('/foo', { recordAccess: true })
+        .should.become(urlData)
+        .then(function() {
+          client.recordAccess.calledOnce.should.be.true
+        })
     })
 
     it('logs an error if the URL is known but recordAccess fails', function() {

--- a/tests/redirect-db-test.js
+++ b/tests/redirect-db-test.js
@@ -79,10 +79,11 @@ describe('RedirectDb', function() {
           return Promise.reject('forced error for ' + url)
         })
 
-      return redirectDb.getRedirect('/foo').should.become(urlData)
+      return redirectDb.getRedirect('/foo', { recordAccess: true })
+        .should.become(urlData)
         .then(function() {
           errorSpy.calledWith('failed to record access for /foo: ' +
-            'forced error for /foo')
+            'forced error for /foo').should.be.true
         })
     })
   })


### PR DESCRIPTION
This will enable the API to use the same underlying `getRedirect()` method without API access counting towards the redirect total.