### PR TITLE
RedisClient,RedirectDb: Change interface contracts

### DIFF
--- a/lib/redirect-db.js
+++ b/lib/redirect-db.js
@@ -2,6 +2,13 @@
 
 module.exports = RedirectDb
 
+function rethrowError(message) {
+  return function(err) {
+    err.message = message + ': ' + err.message
+    throw err
+  }
+}
+
 function RedirectDb(client, logger) {
   this.client = client
   this.logger = logger
@@ -20,20 +27,19 @@ RedirectDb.prototype.getRedirect = function(url, options) {
   })
 }
 
-function attachErrorHandler(promise, errMsg) {
-  return promise.catch(function(err) {
-    throw new Error(errMsg + ': ' + err)
-  })
-}
-
 RedirectDb.prototype.createRedirect = function(url, location, user) {
   var db = this
-  return attachErrorHandler(db.client.createRedirect(url, location, user),
-    'error creating redirection for ' + url + ' to be owned by ' + user)
-    .then(function() {
-      return attachErrorHandler(db.client.addUrlToOwner(user, url),
-        'redirection created for ' + url +
-        ', but failed to add to list for user ' + user)
+
+  return db.client.createRedirect(url, location, user)
+    .catch(rethrowError('error creating redirection for ' + url +
+      ' to be owned by ' + user))
+    .then(function(created) {
+      if (created === false) {
+        return Promise.reject(url + ' already exists')
+      }
+      return db.client.addUrlToOwner(user, url)
+        .catch(rethrowError('redirection created for ' + url +
+          ', but failed to add to list for user ' + user))
     })
 }
 
@@ -54,9 +60,9 @@ RedirectDb.prototype.checkOwnership = function(url, user) {
   return this.client.getRedirect(url)
     .then(function(urlData) {
       if (!urlData) {
-        throw new Error('no redirection exists for ' + url)
+        return Promise.reject('no redirection exists for ' + url)
       } else if (urlData.owner !== user) {
-        throw new Error('redirection for ' + url + ' is owned by ' +
+        return Promise.reject('redirection for ' + url + ' is owned by ' +
           urlData.owner)
       }
     })
@@ -66,24 +72,40 @@ RedirectDb.prototype.updateProperty = function(url, user, property, value) {
   var db = this
   return db.checkOwnership(url, user)
     .then(function() {
-      return attachErrorHandler(db.client.updateProperty(url, property, value),
-        'failed to update ' + property + ' of ' + url + ' to ' + value)
+      return db.client.updateProperty(url, property, value)
+        .catch(rethrowError('failed to update ' + property + ' of ' + url +
+          ' to ' + value))
+    })
+    .then(function(updated) {
+      if (updated === false) {
+        return Promise.reject('property ' + property + ' of ' + url +
+          ' doesn\'t exist')
+      }
     })
 }
 
 RedirectDb.prototype.changeOwner = function(url, user, newOwner) {
   var db = this
-  return db.updateProperty(url, user, 'owner', newOwner)
+  return db.checkOwnership(url, user)
+    .then(function() {
+      return db.updateProperty(url, user, 'owner', newOwner)
+    })
     .then(function() {
       var errPrefix = 'changed ownership of ' + url + ' from ' + user +
             ' to ' + newOwner + ', but failed to '
 
       return Promise.all([
-        attachErrorHandler(db.client.addUrlToOwner(newOwner, url),
-          errPrefix + 'add it to new owner\'s list'),
-        attachErrorHandler(db.client.removeUrlFromOwner(user, url),
-          errPrefix + 'remove it from previous ' + 'owner\'s list')
-      ])
+        db.client.addUrlToOwner(newOwner, url)
+          .catch(rethrowError(errPrefix + 'add it to new owner\'s list')),
+        db.client.removeUrlFromOwner(user, url)
+          .catch(rethrowError(
+            errPrefix + 'remove it from previous owner\'s list'))
+      ]).then(function(values) {
+        if (values[1] === false) {
+          throw new Error('assigned ownership of ' + url + ' to ' + newOwner +
+            ', but ' + user + ' didn\'t own it')
+        }
+      })
     })
 }
 
@@ -95,12 +117,21 @@ RedirectDb.prototype.deleteRedirection = function(url, user) {
   var db = this
   return db.checkOwnership(url, user)
     .then(function() {
-      return attachErrorHandler(db.client.deleteRedirection(url),
-        'failed to delete redirection from ' + url)
+      return db.client.deleteRedirection(url)
+        .catch(rethrowError('failed to delete redirection from ' + url))
     })
-    .then(function() {
-      return attachErrorHandler(db.client.removeUrlFromOwner(user, url),
-        'deleted redirection from ' + url +
-        ', but failed to remove URL from the owner\'s list for ' + user)
+    .then(function(deleted) {
+      if (deleted === false) {
+        return Promise.reject('redirection for ' + url + ' already deleted')
+      }
+      return db.client.removeUrlFromOwner(user, url)
+        .catch(rethrowError('deleted redirection from ' + url +
+          ', but failed to remove URL from the owner\'s list for ' + user))
+    })
+    .then(function(removed) {
+      if (removed === false) {
+        throw new Error('deleted redirection from ' + url + ', but ' + user +
+          ' didn\'t own it')
+      }
     })
 }

--- a/lib/redis-client.js
+++ b/lib/redis-client.js
@@ -41,44 +41,35 @@ RedisClient.prototype.addUrlToOwner = function(owner, url) {
   })
 }
 
-function expectZeroResult(resolve, reject, errMsg) {
-  return function(err, reply) {
-    if (err) {
-      return reject(err)
-    } else if (reply === 0) {
-      return reject(new Error(errMsg))
-    }
-    resolve()
-  }
-}
-
 RedisClient.prototype.removeUrlFromOwner = function(owner, url) {
   var t_ = this
 
   return new Promise(function(resolve, reject) {
-    t_.client.lrem(owner, 1, url,
-      expectZeroResult(resolve, reject,
-        'owner ' + owner + ' didn\'t own ' + url))
+    t_.client.lrem(owner, 1, url, function(err, result) {
+      err ? reject(err) : resolve(result === 1)
+    })
   })
 }
 
 RedisClient.prototype.createRedirect = function(url, location, owner) {
   var t_ = this
 
-  return new Promise(
-    function(resolve, reject) {
-      t_.client.hsetnx(url, 'owner', owner,
-        expectZeroResult(resolve, reject,
-          'redirection already exists for ' + url))
-    })
-    .then(function() {
+  return new Promise(function(resolve, reject) {
+    t_.client.hsetnx(url, 'owner', owner, function(err, result) {
+      if (err) {
+        return reject(err)
+      } else if (result === 0) {
+        return resolve(false)
+      }
       t_.client.hmset(url, 'location', location, 'count', 0, function(err) {
         if (err) {
-          throw new Error('redirection created for ' + url +
-            ', but failed to set location and count: ' + err)
+          return reject(new Error('redirection created for ' + url +
+            ', but failed to set location and count: ' + err))
         }
+        resolve(true)
       })
     })
+  })
 }
 
 RedisClient.prototype.getOwnedRedirects = function(owner) {
@@ -97,11 +88,11 @@ RedisClient.prototype.updateProperty = function(url, property, value) {
   return t_.getRedirect(url)
     .then(function(urlData) {
       if (!urlData) {
-        throw new Error('no redirection for ' + url + ' exists')
+        return Promise.resolve(false)
       }
       return new Promise(function(resolve, reject) {
-        t_.client.hset(url, property, value, function(err) {
-          err ? reject(err) : resolve(urlData[property])
+        t_.client.hset(url, property, value, function(err, result) {
+          err ? reject(err) : resolve(result === 0)
         })
       })
     })
@@ -111,7 +102,8 @@ RedisClient.prototype.deleteRedirection = function(url) {
   var t_ = this
 
   return new Promise(function(resolve, reject) {
-    t_.client.del(url,
-      expectZeroResult(resolve, reject, 'no redirection exists for ' + url))
+    t_.client.del(url, function(err, result) {
+      err ? reject(err) : resolve(result === 1)
+    })
   })
 }

--- a/tests/redis-client-test.js
+++ b/tests/redis-client-test.js
@@ -152,9 +152,14 @@ describe('RedisClient', function() {
         .then(function() {
           return redisClient.removeUrlFromOwner('mbland', '/bar')
         })
-        .then(function() {
+        .should.become(true).then(function() {
           return readOwnerList('mbland').should.become(['/baz', '/foo'])
         })
+    })
+
+    it('returns false if the owner didn\'t own the URL', function() {
+      return redisClient.removeUrlFromOwner('mbland', '/foo')
+        .should.become(false)
     })
 
     it('raises an error if client.lrem fails', function() {
@@ -164,17 +169,12 @@ describe('RedisClient', function() {
       return redisClient.removeUrlFromOwner('mbland', '/foo')
         .should.be.rejectedWith(Error, 'forced error for mbland 1 /foo')
     })
-
-    it('raises an error if the owner didn\'t own the URL', function() {
-      return redisClient.removeUrlFromOwner('mbland', '/foo')
-        .should.be.rejectedWith(Error, 'mbland didn\'t own /foo')
-    })
   })
 
   describe('createRedirect', function() {
     it('creates a new redirection', function() {
       return redisClient.createRedirect('/foo', REDIRECT_TARGET, 'mbland')
-        .should.be.fulfilled.then(function() {
+        .should.become(true).then(function() {
           return redisClient.getRedirect('/foo')
         })
         .should.become({
@@ -184,10 +184,10 @@ describe('RedisClient', function() {
 
     it('fails to create a new redirection when one already exists', function() {
       return redisClient.createRedirect('/foo', REDIRECT_TARGET, 'mbland')
-        .should.be.fulfilled.then(function() {
+        .should.become(true).then(function() {
           return redisClient.createRedirect('/foo', REDIRECT_TARGET, 'mbland')
         })
-        .should.be.rejectedWith(Error, 'redirection already exists for /foo')
+        .should.become(false)
     })
 
     it('raises an error when hsetnx fails', function() {
@@ -249,10 +249,10 @@ describe('RedisClient', function() {
   describe('updateProperty', function() {
     it('successfully updates a property', function() {
       return redisClient.createRedirect('/foo', REDIRECT_TARGET, 'msb')
-        .then(function() {
+        .should.become(true).then(function() {
           return redisClient.updateProperty('/foo', 'owner', 'mbland')
         })
-        .should.become('msb').then(function() {
+        .should.become(true).then(function() {
           return redisClient.getRedirect('/foo')
         })
         .should.become({ owner: 'mbland', location: REDIRECT_TARGET, count: 0 })
@@ -266,9 +266,9 @@ describe('RedisClient', function() {
         .should.be.rejectedWith(Error, 'forced error for /foo')
     })
 
-    it('raises an error if the redirection doesn\'t exist', function() {
+    it('fails if the redirection doesn\'t exist', function() {
       return redisClient.updateProperty('/foo', 'owner', 'mbland')
-        .should.be.rejectedWith(Error, 'no redirection for /foo exists')
+        .should.become(false)
     })
 
     it('raises an error if changing property fails', function() {
@@ -276,7 +276,7 @@ describe('RedisClient', function() {
         cb(new Error('forced error for ' + [url, field, val].join(' ')))
       })
       return redisClient.createRedirect('/foo', REDIRECT_TARGET, 'msb')
-        .then(function() {
+        .should.become(true).then(function() {
           return redisClient.updateProperty('/foo', 'owner', 'mbland')
         })
         .should.be.rejectedWith(Error, 'forced error for /foo owner')
@@ -286,18 +286,17 @@ describe('RedisClient', function() {
   describe('deleteRedirection', function() {
     it('successfully deletes the redirection', function() {
       return redisClient.createRedirect('/foo', REDIRECT_TARGET, 'mbland')
-        .then(function() {
+        .should.become(true).then(function() {
           return redisClient.deleteRedirection('/foo')
         })
-        .should.be.fulfilled.then(function() {
+        .should.become(true).then(function() {
           return redisClient.getRedirect('/foo')
         })
         .should.become(null)
     })
 
-    it('raises an error if the redirection doesn\'t exist', function() {
-      return redisClient.deleteRedirection('/foo')
-        .should.be.rejectedWith(Error, 'no redirection exists for /foo')
+    it('returns false if the redirection doesn\'t exist', function() {
+      return redisClient.deleteRedirection('/foo').should.become(false)
     })
 
     it('raises an error if client.del fails', function() {
@@ -305,7 +304,7 @@ describe('RedisClient', function() {
         cb(new Error('forced error for ' + key))
       })
       return redisClient.createRedirect('/foo', REDIRECT_TARGET, 'mbland')
-        .then(function() {
+        .should.become(true).then(function() {
           return redisClient.deleteRedirection('/foo')
         })
         .should.be.rejectedWith(Error, 'forced error for /foo')


### PR DESCRIPTION
After starting to write the API router, I realized it would be better to distinguish between forbidden or disallowed operations (HTTP 403 and related) and internal errors (HTTP 500).

RedisClient now returns a Boolean if an operation was carried out successfully, based on whether the result matched what was expected; and throws Errors only when an operation failed.

RedirectDb now returns a rejected Promise containing a string on forbidden/disallowed operations and an Error if a client operation failed or an unexpected internal error occurred.