### PR TITLE
Add API router, first handler for /info

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,23 +7,54 @@ module.exports = {
   assembleApp: assembleApp
 }
 
-function makeErrorHandler(req, res, logger) {
-  return function(err) {
-    logger.error(err)
-    res.status(500)
-    res.send('Error while processing ' + req.originalUrl + ': ' + err)
-  }
-}
-
 function assembleApp(app, redirectDb, logger) {
   app.use(express.static(path.join(__dirname, '..', 'public')))
+  app.use('/api', assembleApiRouter(redirectDb, logger))
 
   app.get('/*', function(req, res) {
     redirectDb.getRedirect(req.path, { recordAccess: true })
       .then(function(urlData) {
         res.redirect(urlData !== null ? urlData.location : '/?url=' + req.path)
       })
-      .catch(makeErrorHandler(req, res, logger))
+      .catch(errorHandler(req, res, logger))
   })
   return app
+}
+
+function errorHandler(req, res, logger, method) {
+  return function(err) {
+    var response
+    logger.error(err)
+
+    if (err instanceof Error) {
+      res.sendStatus(500)
+    } else {
+      response = (method === 'json') ? { err: err } : err
+      res.status(403)[method || 'send'](response)
+    }
+  }
+}
+
+function assembleApiRouter(redirectDb, logger) {
+  var router = express.Router(),
+      urlParam = ':url(/[A-Za-z0-9_.-]+)'
+
+  router.get('/info' + urlParam, function(req, res) {
+    redirectDb.getRedirect(req.params.url)
+      .then(function(urlInfo) {
+        if (urlInfo !== null) {
+          res.status(200)
+          res.json(urlInfo)
+        } else {
+          res.sendStatus(404)
+        }
+      })
+      .catch(errorHandler(req, res, logger, 'json'))
+  })
+
+  router.all('/*', function(req, res) {
+    res.sendStatus(400)
+  })
+
+  return router
 }

--- a/tests/app-test.js
+++ b/tests/app-test.js
@@ -13,12 +13,20 @@ chai.should()
 chai.use(chaiAsPromised)
 
 describe('assembleApp', function() {
-  var app, redirectDb, logger
+  var app, redirectDb, logger, logError
 
   before(function() {
     redirectDb = new RedirectDb
     logger = { error: function() { } }
     app = new assembleApp(express(), redirectDb, logger)
+  })
+
+  beforeEach(function() {
+    logError = sinon.spy(logger, 'error')
+  })
+
+  afterEach(function() {
+    logError.restore()
   })
 
   describe('get homepage and redirects', function() {
@@ -35,8 +43,7 @@ describe('assembleApp', function() {
     it('returns the index page', function() {
       return request(app)
         .get('/')
-        .expect(200)
-        .expect(/Url Pointers/)
+        .expect(200, /Url Pointers/)
     })
 
     it('redirects to the url returned by the RedirectDb', function() {
@@ -62,8 +69,6 @@ describe('assembleApp', function() {
     })
 
     it('reports an error', function() {
-      var logError = sinon.spy(logger, 'error')
-
       getRedirect.withArgs('/foo', { recordAccess: true })
         .callsFake(function() {
           return Promise.reject(new Error('forced error'))
@@ -71,12 +76,68 @@ describe('assembleApp', function() {
 
       return request(app)
         .get('/foo')
-        .expect(500)
-        .expect('Error while processing /foo: Error: forced error')
+        .expect(500, 'Internal Server Error')
         .then(function() {
           logError.calledOnce.should.be.true
           expect(logError.args[0][0].message).to.equal('forced error')
         })
+    })
+  })
+
+  describe('API', function() {
+    describe('unknown or malformed request', function() {
+      it('returns bad request', function() {
+        return request(app)
+          .get('/api')
+          .expect(400, 'Bad Request')
+      })
+    })
+
+    describe('/info', function() {
+      var getRedirect
+
+      beforeEach(function() {
+        getRedirect = sinon.stub(redirectDb, 'getRedirect')
+      })
+
+      afterEach(function() {
+        getRedirect.restore()
+      })
+
+      it('returns info for an existing URL', function() {
+        var urlData = {
+          location: 'https://mike-bland.com/', owner: 'mbland', count: 27 }
+        getRedirect.withArgs('/foo').returns(Promise.resolve(urlData))
+
+        return request(app)
+          .get('/api/info/foo')
+          .expect(200)
+          .then(function(response) {
+            response.body.should.eql(urlData)
+          })
+      })
+
+      it('returns not found', function() {
+        getRedirect.withArgs('/foo').returns(Promise.resolve(null))
+
+        return request(app)
+          .get('/api/info/foo')
+          .expect(404, 'Not Found')
+      })
+
+      it('returns server error', function() {
+        getRedirect.withArgs('/foo').callsFake(function() {
+          return Promise.reject(new Error('forced error'))
+        })
+
+        return request(app)
+          .get('/api/info/foo')
+          .expect(500, 'Internal Server Error')
+          .expect(function() {
+            logError.calledOnce.should.be.true
+            expect(logError.args[0][0].message).to.equal('forced error')
+          })
+      })
     })
   })
 })


### PR DESCRIPTION
Also contains minor internal refactorings to share the error handler implementation between the API router and the other app routes.