### PR TITLE
Rename variables and functions, fix (de)serializeUser bug

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "PORT": 3000,
   "AUTH_PROVIDERS": [ "google" ],
-  "GOOGLE_REDIRECT_URL": "http://localhost:3000/auth/callback",
+  "GOOGLE_CALLBACK_URL": "http://localhost:3000/auth/callback",
   "users": [
   ],
   "domains": [

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -4,8 +4,8 @@ module.exports = exports = {
   assemble: assemble,
   findVerifiedId: findVerifiedId,
   verify: verify,
-  serializeUser: serializeUser,
-  deserializeUser: deserializeUser
+  makeUserSerializer: makeUserSerializer,
+  makeUserDeserializer: makeUserDeserializer
 }
 
 function assemble(passport, redirectDb, config) {
@@ -17,8 +17,8 @@ function assemble(passport, redirectDb, config) {
       throw err
     }
   })
-  passport.serializeUser(serializeUser)
-  passport.deserializeUser(deserializeUser)
+  passport.serializeUser(makeUserSerializer(redirectDb))
+  passport.deserializeUser(makeUserDeserializer(redirectDb))
 }
 
 function findVerifiedId(userIds, config) {
@@ -51,13 +51,13 @@ function sendUserOnSuccess(redirectDbOp, done) {
     .catch(done)
 }
 
-function serializeUser() {
+function makeUserSerializer() {
   return function(user, done) {
     done(null, user.id)
   }
 }
 
-function deserializeUser(redirectDb) {
+function makeUserDeserializer(redirectDb) {
   return function(userId, done) {
     sendUserOnSuccess(redirectDb.findUser(userId), done)
   }

--- a/lib/auth/google.js
+++ b/lib/auth/google.js
@@ -6,7 +6,7 @@ module.exports = {
   config: {
     GOOGLE_CLIENT_ID: 'application ID for Google OAuth',
     GOOGLE_CLIENT_SECRET: 'application secret for Google OAuth',
-    GOOGLE_REDIRECT_URL: 'URL to which Google OAuth will redirect the client'
+    GOOGLE_CALLBACK_URL: 'URL to which Google OAuth will redirect the client'
   },
 
   assemble: assemble,

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,12 +19,13 @@ function sessionParams(config, sessionStore) {
   } else if (maxAge !== null && maxAge < 0) {
     throw new Error('SESSION_MAX_AGE cannot be negative: ' + maxAge)
   }
+  sessionStore = sessionStore || null
 
   return {
     store: sessionStore,
     secret: config.SESSION_SECRET,
-    resave: sessionStore === undefined || sessionStore.touch === undefined,
-    saveUnitialized: false,
+    resave: sessionStore === null || sessionStore.touch === undefined,
+    saveUninitialized: false,
     maxAge: maxAge === null ? null : maxAge * 1000
   }
 }

--- a/tests/app-test.js
+++ b/tests/app-test.js
@@ -148,10 +148,10 @@ describe('sessionParams', function() {
   it('uses default session store and max age', function() {
     var params = sessionParams({SESSION_SECRET: 'secret'})
     params.should.eql({
-      store: undefined,
+      store: null,
       secret: 'secret',
       resave: true,
-      saveUnitialized: false,
+      saveUninitialized: false,
       maxAge: appLib.DEFAULT_SESSION_MAX_AGE * 1000
     })
   })
@@ -165,7 +165,7 @@ describe('sessionParams', function() {
       store: store,
       secret: 'secret',
       resave: true,
-      saveUnitialized: false,
+      saveUninitialized: false,
       maxAge: 3600 * 1000
     })
   })
@@ -179,7 +179,7 @@ describe('sessionParams', function() {
       store: store,
       secret: 'secret',
       resave: false,
-      saveUnitialized: false,
+      saveUninitialized: false,
       maxAge: null
     })
   })

--- a/tests/auth-test.js
+++ b/tests/auth-test.js
@@ -233,7 +233,7 @@ describe('auth', function() {
         AUTH_PROVIDERS: [ 'google', 'test' ],
         GOOGLE_CLIENT_ID: '<client-id>',
         GOOGLE_CLIENT_SECRET: '<client-secret>',
-        GOOGLE_REDIRECT_URL: '<redirect-url>'
+        GOOGLE_CALLBACK_URL: '<redirect-url>'
       })
       expect(passport.use.getCall(0).args[0].name).to.equal('google')
       expect(passport.use.getCall(1).args[0].name).to.equal('test')

--- a/tests/config-test.js
+++ b/tests/config-test.js
@@ -63,12 +63,12 @@ describe('config', function() {
         errors = [
           'missing GOOGLE_CLIENT_ID',
           'missing GOOGLE_CLIENT_SECRET',
-          'missing GOOGLE_REDIRECT_URL'
+          'missing GOOGLE_CALLBACK_URL'
         ]
 
     delete configData.GOOGLE_CLIENT_ID
     delete configData.GOOGLE_CLIENT_SECRET
-    delete configData.GOOGLE_REDIRECT_URL
+    delete configData.GOOGLE_CALLBACK_URL
     expect(function() { return new Config(configData) }).to.throw(Error,
       'Invalid configuration:\n  ' + errors.join('\n  '))
   })
@@ -107,7 +107,7 @@ describe('config', function() {
           'SESSION_MAX_AGE',
           'GOOGLE_CLIENT_ID',
           'GOOGLE_CLIENT_SECRET',
-          'GOOGLE_REDIRECT_URL'
+          'GOOGLE_CALLBACK_URL'
         ],
         config
 
@@ -128,8 +128,8 @@ describe('config', function() {
       .to.equal(compareConfig.GOOGLE_CLIENT_ID)
     expect(config.GOOGLE_CLIENT_SECRET)
       .to.equal(compareConfig.GOOGLE_CLIENT_SECRET)
-    expect(config.GOOGLE_REDIRECT_URL)
-      .to.equal(compareConfig.GOOGLE_REDIRECT_URL)
+    expect(config.GOOGLE_CALLBACK_URL)
+      .to.equal(compareConfig.GOOGLE_CALLBACK_URL)
   })
 
   it('loads a valid config from a direct file path', function() {

--- a/tests/helpers/test-config.json
+++ b/tests/helpers/test-config.json
@@ -5,7 +5,7 @@
   "SESSION_MAX_AGE": 3600,
   "GOOGLE_CLIENT_ID": "<google client ID>",
   "GOOGLE_CLIENT_SECRET": "<google client secret>",
-  "GOOGLE_REDIRECT_URL": "http://localhost:3000/auth/callback",
+  "GOOGLE_CALLBACK_URL": "http://localhost:3000/auth/callback",
   "users": [
     "mbland@acm.org"
   ],


### PR DESCRIPTION
I hadn't noticed I'd spelled `saveUninitialized` incorrectly until a new test emitted an express-session deprecation warning. This change also explicitly sets `sessionStore` to `null` when it's `undefined`.

Renamed `GOOGLE_REDIRECT_URL` to `GOOGLE_CALLBACK_URL` for semantic clarity.

Also, while trying to run the app with actual Google OAuth authentication, the OAuth callback request would hang. I eventually realized it was because I'd written `auth.serializeUser()` and `auth.deserializeUser()` as factory functions, but was passing them directly to `passport.serializeUser()` and `passport.deserializeUser()`. Invoking the factory functions resolved the hangup.

To avoid such confusion in the future, I've renamed the factory functions to `makeUserSerializer()` and `makeUserDeserializer()`.