### PR TITLE
Integrate and test passport authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
 # Are your editor's temp files, OS metadata files, etc. showing up in `git
 # status`? Try adding them to `$HOME/.config/git/ignore` instead.
-test-config*.json
+.nyc_output/
 coverage/
 dump.rdb
 node_modules/
 scripts/go-script-bash/
+test-config*.json
 tests/bats/
 tests/coverage/
 tests/kcov/

--- a/index.js
+++ b/index.js
@@ -20,14 +20,20 @@ if (config.REDIS_PORT !== undefined) {
   redisClientOptions.port = config.REDIS_PORT
 }
 
+var redisClient = redis.createClient(redisClientOptions)
+
 app.use(morgan('combined'))
 urlPointers.assembleApp(
   app,
-  new RedirectDb(
-    new RedisClient(redis.createClient(redisClientOptions), logger)),
+  new RedirectDb(new RedisClient(redisClient, logger)),
   logger,
   new RedisStore,
   config)
 
-app.listen(config.PORT)
+var server = app.listen(config.PORT)
+
+process.on('exit', function() {
+  server.close()
+  redisClient.quit()
+})
 logger.log(packageInfo.name + ' listening on port ' + config.PORT)

--- a/index.js
+++ b/index.js
@@ -9,18 +9,25 @@ var app = express()
 var redis = require('redis')
 var RedirectDb = require('./lib/redirect-db')
 var RedisClient = require('./lib/redis-client')
+var redisClientOptions = {}
 var session = require('express-session')
 var RedisStore = require('connect-redis')(session)
 var urlPointers = require('./lib')
 var morgan = require('morgan')
 var logger = console
 
+if (config.REDIS_PORT !== undefined) {
+  redisClientOptions.port = config.REDIS_PORT
+}
+
 app.use(morgan('combined'))
 urlPointers.assembleApp(
   app,
-  new RedirectDb(new RedisClient(redis.createClient(), logger)),
+  new RedirectDb(
+    new RedisClient(redis.createClient(redisClientOptions), logger)),
   logger,
   new RedisStore,
   config)
+
 app.listen(config.PORT)
 logger.log(packageInfo.name + ' listening on port ' + config.PORT)

--- a/index.js
+++ b/index.js
@@ -9,12 +9,18 @@ var app = express()
 var redis = require('redis')
 var RedirectDb = require('./lib/redirect-db')
 var RedisClient = require('./lib/redis-client')
+var session = require('express-session')
+var RedisStore = require('connect-redis')(session)
 var urlPointers = require('./lib')
+var morgan = require('morgan')
 var logger = console
 
+app.use(morgan('combined'))
 urlPointers.assembleApp(
   app,
   new RedirectDb(new RedisClient(redis.createClient(), logger)),
-  logger)
+  logger,
+  new RedisStore,
+  config)
 app.listen(config.PORT)
 logger.log(packageInfo.name + ' listening on port ' + config.PORT)

--- a/lib/auth/test.js
+++ b/lib/auth/test.js
@@ -3,17 +3,21 @@
 module.exports = {
   config:  {},
   assemble: assemble,
-  strategy: new TestStrategy
+  strategyImpl: {
+    authenticate: function() {
+      throw new Error('strategyImpl.authenticate() must be stubbed')
+    }
+  }
 }
 
 function assemble(passport) {
-  passport.use(module.exports.strategy)
+  passport.use(new TestStrategy)
 }
 
 function TestStrategy() {
   this.name = 'test'
 }
 
-TestStrategy.prototype.authenticate = function() {
-  throw new Error('TestStrategy.authenticate() must be stubbed')
+TestStrategy.prototype.authenticate = function(req, options) {
+  module.exports.strategyImpl.authenticate(req, options, this)
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,7 +8,8 @@ function Config(configData) {
   var config = this,
       numericValues = {
         PORT: true,
-        SESSION_MAX_AGE: true
+        SESSION_MAX_AGE: true,
+        REDIS_PORT: true
       }
 
   applyEnvUpdates(configData)
@@ -45,6 +46,7 @@ var schema = {
   },
   optionalTopLevelFields: {
     SESSION_MAX_AGE: 'maximum age of a session, in seconds',
+    REDIS_PORT: 'redis-server port',
     users: 'list of authorized usernames (email addresses)',
     domains: 'list of authorized domains'
   },
@@ -67,7 +69,8 @@ function applyEnvUpdates(configData) {
     'PORT',
     'AUTH_PROVIDERS',
     'SESSION_SECRET',
-    'SESSION_MAX_AGE'
+    'SESSION_MAX_AGE',
+    'REDIS_PORT'
   ]
 
   envProperties.forEach(assignEnvVarToConfigProperty(configData))

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,11 @@
 'use strict'
 
+var auth = require('./auth')
 var path = require('path')
 var express = require('express')
+var session = require('express-session')
+var passport = require('passport')
+var ensureLoggedIn = require('connect-ensure-login').ensureLoggedIn
 
 module.exports = exports = {
   assembleApp: assembleApp,
@@ -32,7 +36,25 @@ function sessionParams(config, sessionStore) {
   }
 }
 
-function assembleApp(app, redirectDb, logger) {
+function assembleApp(app, redirectDb, logger, sessionStore, config) {
+  auth.assemble(passport, redirectDb, config)
+  app.use(session(sessionParams(config, sessionStore)))
+  app.use(passport.initialize())
+  app.use(passport.session())
+
+  app.get('/auth',
+    passport.authenticate(config.AUTH_PROVIDERS,
+      { scope: [ 'profile', 'email' ] }))
+  app.get('/auth/callback',
+    passport.authenticate(config.AUTH_PROVIDERS,
+      { failureRedirect: '/auth', successReturnToOrRedirect: '/' }))
+
+  app.get('/logout', function(req, res) {
+    req.logout()
+    res.redirect('/auth')
+  })
+
+  app.use('/', ensureLoggedIn('/auth'))
   app.use(express.static(path.join(__dirname, '..', 'public')))
   app.use('/api', assembleApiRouter(redirectDb, logger))
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,8 @@ module.exports = exports = {
 }
 
 function sessionParams(config, sessionStore) {
-  var maxAge = config.SESSION_MAX_AGE
+  var maxAge = config.SESSION_MAX_AGE,
+      doResave
 
   if (maxAge === undefined) {
     maxAge = exports.DEFAULT_SESSION_MAX_AGE
@@ -20,12 +21,13 @@ function sessionParams(config, sessionStore) {
     throw new Error('SESSION_MAX_AGE cannot be negative: ' + maxAge)
   }
   sessionStore = sessionStore || null
+  doResave = sessionStore === null || sessionStore.touch === undefined
 
   return {
     store: sessionStore,
     secret: config.SESSION_SECRET,
-    resave: sessionStore === null || sessionStore.touch === undefined,
-    saveUninitialized: false,
+    resave: doResave,
+    saveUninitialized: doResave,
     maxAge: maxAge === null ? null : maxAge * 1000
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "supertest": "^3.0.0"
   },
   "dependencies": {
+    "connect-redis": "^3.3.0",
     "express": "^4.15.2",
+    "express-session": "^1.15.2",
+    "passport": "^0.3.2",
     "passport-google-oauth20": "^1.0.0",
     "redis": "^2.7.1"
   }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "codeclimate-test-reporter": "^0.4.1",
     "coveralls": "^2.13.1",
     "eslint": "^3.19.0",
-    "istanbul": "^0.4.5",
     "mocha": "^3.3.0",
+    "nyc": "^10.3.2",
     "sinon": "^2.1.0",
     "supertest": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "connect-redis": "^3.3.0",
     "express": "^4.15.2",
     "express-session": "^1.15.2",
+    "morgan": "^1.8.1",
     "passport": "^0.3.2",
     "passport-google-oauth20": "^1.0.0",
     "redis": "^2.7.1"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "coveralls": "^2.13.1",
     "eslint": "^3.19.0",
     "istanbul": "^0.4.5",
-    "live-server": "^1.2.0",
     "mocha": "^3.3.0",
     "sinon": "^2.1.0",
     "supertest": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "codeclimate-test-reporter": "^0.4.1",
     "coveralls": "^2.13.1",
     "eslint": "^3.19.0",
+    "istanbul": "^0.4.5",
     "mocha": "^3.3.0",
     "nyc": "^10.3.2",
     "sinon": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "supertest": "^3.0.0"
   },
   "dependencies": {
+    "connect-ensure-login": "^0.1.1",
     "connect-redis": "^3.3.0",
     "express": "^4.15.2",
     "express-session": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "codeclimate-test-reporter": "^0.4.1",
     "coveralls": "^2.13.1",
     "eslint": "^3.19.0",
-    "istanbul": "^0.4.5",
     "mocha": "^3.3.0",
     "nyc": "^10.3.2",
     "sinon": "^2.1.0",

--- a/scripts/serve
+++ b/scripts/serve
@@ -1,9 +1,9 @@
 #! /usr/local/env bash
 #
-# Runs a local development server at http://localhost:8080
+# Runs a local url-pointers server
 
 urlp.serve() {
-  live-server public/
+  node "$_GO_ROOTDIR/index.js" "$_GO_ROOTDIR/test-config.json"
 }
 
 urlp.serve "$@"

--- a/scripts/test
+++ b/scripts/test
@@ -118,7 +118,7 @@ _test_run_mocha() {
     $(@go 'glob' "${__GO_TEST_GLOB_ARGS[@]}" "${__test_glob_patterns[@]}"))
 
   if [[ "$__COVERAGE_RUN" == 'true' ]]; then
-    istanbul -- cover node_modules/.bin/_mocha "${argv[@]}"
+    nyc --reporter=lcov node_modules/.bin/_mocha "${argv[@]}"
   else
     mocha "${argv[@]}"
   fi

--- a/scripts/test
+++ b/scripts/test
@@ -127,9 +127,11 @@ _test_run_mocha() {
 _test_coverage() {
   local report_path="${_GO_ROOTDIR}/coverage/lcov-report/index.html"
   local lcov_info_path="${_GO_ROOTDIR}/coverage/lcov.info"
+  local result=0
 
   rm -f "$report_path"
   __COVERAGE_RUN='true' _test_run_mocha "${@:2}"
+  result="$?"
 
   if [[ ! -r "$report_path" ]]; then
     return 1
@@ -155,6 +157,7 @@ _test_coverage() {
       echo 'https://codeclimate.com/github/mbland/slack-github-issues'
     fi
   fi
+  return "$result"
 }
 
 _test() {

--- a/tests/app-test.js
+++ b/tests/app-test.js
@@ -151,7 +151,7 @@ describe('sessionParams', function() {
       store: null,
       secret: 'secret',
       resave: true,
-      saveUninitialized: false,
+      saveUninitialized: true,
       maxAge: appLib.DEFAULT_SESSION_MAX_AGE * 1000
     })
   })
@@ -165,7 +165,7 @@ describe('sessionParams', function() {
       store: store,
       secret: 'secret',
       resave: true,
-      saveUninitialized: false,
+      saveUninitialized: true,
       maxAge: 3600 * 1000
     })
   })

--- a/tests/config-test.js
+++ b/tests/config-test.js
@@ -105,11 +105,15 @@ describe('config', function() {
           'AUTH_PROVIDERS',
           'SESSION_SECRET',
           'SESSION_MAX_AGE',
+          'REDIS_PORT',
           'GOOGLE_CLIENT_ID',
           'GOOGLE_CLIENT_SECRET',
           'GOOGLE_CALLBACK_URL'
         ],
         config
+
+    inputConfig.REDIS_PORT = 666
+    compareConfig.REDIS_PORT = 666
 
     properties.forEach(function(name) {
       var value = inputConfig[name]
@@ -124,6 +128,8 @@ describe('config', function() {
       .to.equal(compareConfig.SESSION_SECRET)
     expect(config.SESSION_MAX_AGE)
       .to.equal(compareConfig.SESSION_MAX_AGE)
+    expect(config.REDIS_PORT)
+      .to.equal(compareConfig.REDIS_PORT)
     expect(config.GOOGLE_CLIENT_ID)
       .to.equal(compareConfig.GOOGLE_CLIENT_ID)
     expect(config.GOOGLE_CLIENT_SECRET)

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -43,5 +43,15 @@ module.exports = {
           ': ' + err))
       })
     })
+  },
+
+  killServer: function(server, signal) {
+    return new Promise(function(resolve) {
+      signal = signal || 'SIGTERM'
+      server.on('exit', function() {
+        resolve()
+      })
+      server.kill(signal)
+    })
   }
 }

--- a/tests/redis-client-test.js
+++ b/tests/redis-client-test.js
@@ -43,7 +43,8 @@ describe('RedisClient', function() {
   })
 
   after(function() {
-    redisServer.kill()
+    clientImpl.quit()
+    return helpers.killServer(redisServer)
   })
 
   setData = function(url, redirectTarget, owner, count) {

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -36,7 +36,7 @@ describe('Smoke test', function() {
       urlpServer.stdout.on('data', function(data) {
         stdout += data
         if (stdout.match(packageInfo.name + ' listening on port ')) {
-          setTimeout(resolve, 100)
+          setTimeout(resolve, 250)
         }
       })
       urlpServer.stderr.on('data', function(data) {

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -1,0 +1,70 @@
+'use strict'
+
+var spawn = require('child_process').spawn
+var path = require('path')
+var helpers = require('./helpers')
+var chai = require('chai')
+var chaiAsPromised = require('chai-as-promised')
+
+var rootDir = path.dirname(__dirname)
+var packageInfo = require(path.join(rootDir, 'package.json'))
+var scriptPath = path.join(rootDir, packageInfo.main)
+var testConfigPath = path.join(rootDir, 'tests', 'helpers', 'test-config.json')
+
+chai.should()
+chai.use(chaiAsPromised)
+
+describe('Smoke test', function() {
+  var urlpServer, redisServer, launchServer, stdout, stderr, exitCode = 0
+
+  before(function() {
+    return helpers.pickUnusedPort()
+      .then(helpers.launchRedis)
+      .then(function(redisData) {
+        process.env.URL_POINTERS_REDIS_PORT = redisData.port
+        redisServer = redisData.server
+      })
+  })
+
+  launchServer = function() {
+    return new Promise(function(resolve, reject) {
+      stdout = ''
+      stderr = ''
+
+      urlpServer = spawn('node', [ scriptPath, testConfigPath ])
+
+      urlpServer.stdout.on('data', function(data) {
+        stdout += data
+      })
+      urlpServer.stderr.on('data', function(data) {
+        stderr += data
+      })
+      urlpServer.on('close', function(code) {
+        exitCode = code
+      })
+      urlpServer.on('error', function(err) {
+        err.message = 'failed to start ' + scriptPath + ': ' + err.message
+        reject(err)
+      })
+
+      setTimeout(resolve, 500)
+    })
+  }
+
+  afterEach(function() {
+    return helpers.killServer(urlpServer)
+  })
+
+  after(function() {
+    return helpers.killServer(redisServer)
+  })
+
+  it('launches successfully using a well-formed config file', function() {
+    return launchServer().should.be.fulfilled
+      .then(function() {
+        stdout.should.have.string(packageInfo.name + ' listening on port ')
+        stderr.should.equal('')
+        exitCode.should.equal(0)
+      })
+  })
+})

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -61,11 +61,14 @@ describe('Smoke test', function() {
     return helpers.killServer(redisServer)
   })
 
-  it('launches successfully using a well-formed config file', function() {
-    return launchServer().should.be.fulfilled
-      .then(function() {
-        stderr.should.equal('')
-        exitCode.should.equal(0)
-      })
+  describe('launches successfully', function() {
+    beforeEach(function() {
+      return launchServer()
+    })
+
+    it('launches successfully using a well-formed config file', function() {
+      stderr.should.equal('')
+      exitCode.should.equal(0)
+    })
   })
 })

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -35,9 +35,13 @@ describe('Smoke test', function() {
 
       urlpServer.stdout.on('data', function(data) {
         stdout += data
+        if (stdout.match(packageInfo.name + ' listening on port ')) {
+          setTimeout(resolve, 100)
+        }
       })
       urlpServer.stderr.on('data', function(data) {
         stderr += data
+        reject(new Error(stderr))
       })
       urlpServer.on('close', function(code) {
         exitCode = code
@@ -46,8 +50,6 @@ describe('Smoke test', function() {
         err.message = 'failed to start ' + scriptPath + ': ' + err.message
         reject(err)
       })
-
-      setTimeout(resolve, 500)
     })
   }
 
@@ -62,7 +64,6 @@ describe('Smoke test', function() {
   it('launches successfully using a well-formed config file', function() {
     return launchServer().should.be.fulfilled
       .then(function() {
-        stdout.should.have.string(packageInfo.name + ' listening on port ')
         stderr.should.equal('')
         exitCode.should.equal(0)
       })


### PR DESCRIPTION
[Passport](http://passportjs.org/) integration is finally integrated and fully tested. The following article provided the key insight necessary for testing this integration, which was to ditch supertest.agent (which wasn't working for me) and capture the session cookie instead:

- ["Testing Authenticated Requests with Supertest" by Juha Hytönen](https://medium.com/@juha.a.hytonen/testing-authenticated-requests-with-supertest-325ccf47c2bb)

A server configured with actual Google application credentials can now successfully serve the homepage, API endpoints, and redirects, run via:

```sh
$ node ./index.js path/to/config.js
```

Also adds [morgan](https://www.npmjs.com/package/morgan) for request logging.