### PR TITLE
Add `./go tests browser` using mocha-phantomjs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,6 @@
 **/vendor/*.js
 coverage/*
 node_modules/*
+public/tests/phantomjs.js
 public/tests/vendor/*
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 coverage/
 dump.rdb
 node_modules/
+public/tests/phantomjs.js
 scripts/go-script-bash/
 test-config*.json
 tests/bats/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - node
 - '4.2'
 script:
-- "./go lint && ./go test --coverage"
+- "./go lint && ./go test --coverage && ./go test browser"
 env:
   matrix:
     secure: "HFeQtlJi3JNCbONSm498Y/EJQ8TO29Te/iD8f5fduacZi7jF0AZUwJBjrIzpmtLhKKvCLRn8BDb11QJrF9c2jZXCX/EouJldMpVHz7pPRVueWk3BaWI6BJpgeCD3SSuMaFTmZUYhhLlrvfVEUWAzxKauKkcQvIxRvjSgC8uyrFYQBbOF8mWLc4AhPgJutCz8HlgMJQF6xO7vblMW5qORQog3vl3445+sAACLqGu7N3CH+fipPa5Yfua0JUJbtf/oQVoMW+eUmMxAGOOS/10mLGTkeN0wIxTYdv10Z1rI9ijAZLUni6p1osdsypOuOzfXSYcPvB3w5OkOrTcO9uHqMxZc9YNblZe7x3Uzg3eMWN7yzl1MyuR/RIsYwjsW+3dSuGxhvznvhzr9mDAhgaBOkUPmb8qyL4r2cXIgVbAEdKiVIAha8XJFlTOT/VWlTvuNJHmvPN2KjpdtNcmkj1pPSaXSAKe738dQhJyzxE1+LJsNIxgAqdMNOvDBWLnBRgMGyZGCLVHflSBs5a6iF6UvlGrS6fpTLyVmNTG4PbnIN1kJm247MNvuKZi5Kj7fc3Yrt01VZPOP5b/00PibvRd7sudH2t0xLNHR1iaFOn2U3rwHSW+NBIhJd2Ms/BibEgOO628wXJnmHA36XEJxVBpgNZp4uL1jUAEvVj6GE4jFnGM="

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - node
 - '4.2'
 script:
-- "./go lint && ./go test --coverage && ./go test browser"
+- "./go lint && ./go test --coverage"
 env:
   matrix:
     secure: "HFeQtlJi3JNCbONSm498Y/EJQ8TO29Te/iD8f5fduacZi7jF0AZUwJBjrIzpmtLhKKvCLRn8BDb11QJrF9c2jZXCX/EouJldMpVHz7pPRVueWk3BaWI6BJpgeCD3SSuMaFTmZUYhhLlrvfVEUWAzxKauKkcQvIxRvjSgC8uyrFYQBbOF8mWLc4AhPgJutCz8HlgMJQF6xO7vblMW5qORQog3vl3445+sAACLqGu7N3CH+fipPa5Yfua0JUJbtf/oQVoMW+eUmMxAGOOS/10mLGTkeN0wIxTYdv10Z1rI9ijAZLUni6p1osdsypOuOzfXSYcPvB3w5OkOrTcO9uHqMxZc9YNblZe7x3Uzg3eMWN7yzl1MyuR/RIsYwjsW+3dSuGxhvznvhzr9mDAhgaBOkUPmb8qyL4r2cXIgVbAEdKiVIAha8XJFlTOT/VWlTvuNJHmvPN2KjpdtNcmkj1pPSaXSAKe738dQhJyzxE1+LJsNIxgAqdMNOvDBWLnBRgMGyZGCLVHflSBs5a6iF6UvlGrS6fpTLyVmNTG4PbnIN1kJm247MNvuKZi5Kj7fc3Yrt01VZPOP5b/00PibvRd7sudH2t0xLNHR1iaFOn2U3rwHSW+NBIhJd2Ms/BibEgOO628wXJnmHA36XEJxVBpgNZp4uL1jUAEvVj6GE4jFnGM="

--- a/package.json
+++ b/package.json
@@ -24,13 +24,16 @@
   },
   "homepage": "https://github.com/mbland/url-pointers#readme",
   "devDependencies": {
+    "browserify": "^14.3.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "codeclimate-test-reporter": "^0.4.1",
     "coveralls": "^2.13.1",
+    "es6-promise": "^4.1.0",
     "eslint": "^3.19.0",
     "live-server": "^1.2.0",
     "mocha": "^3.3.0",
+    "mocha-phantomjs": "^4.1.0",
     "nyc": "^10.3.2",
     "sinon": "^2.1.0",
     "supertest": "^3.0.0"

--- a/public/app.js
+++ b/public/app.js
@@ -2,7 +2,7 @@
 'use strict';
 
 (function(f) { f(window, document) })(function(window/*,  document */) {
-  var urlp = window.urlp = (window.urlp || {})
+  var urlp = window.urlp = {}
 
   urlp.xhr = function(method, url) {
     return new Promise(function(resolve, reject) {

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
       <div class='row'>
         <h3>Url Pointers</h3>
         <p>Placeholder for default view.</p>
+        <a href='' class='button button-primary'>Create URL</a>
       </div>
     </div>
   </div>

--- a/public/tests/index.html
+++ b/public/tests/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="mocha"></div>
+    <script src="phantomjs.js"></script>
     <script src="/app.js"></script>
     <script src="vendor/mocha.js"></script>
     <script src="vendor/chai.js"></script>

--- a/public/tests/lib.js
+++ b/public/tests/lib.js
@@ -2,7 +2,7 @@
 'use strict';
 
 (function(f) { f(window, document) })(function(window, document) {
-  var urlp = window.urlp = (window.urlp || {})
+  var urlp = window.urlp
   var urlpTest = window.urlpTest = {}
   var fixture = urlpTest.fixture = document.createElement('div')
 

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -4,7 +4,7 @@
 describe('UrlPointers', function() {
   var urlpTest = window.urlpTest
 
-  it('shows the default container', function() {
+  it('shows the default view', function() {
     urlpTest.getView('').length.should.equal(1)
   })
 })

--- a/scripts/lint
+++ b/scripts/lint
@@ -9,7 +9,7 @@
 # arguments, only lints files matching '<glob>.js'.
 
 declare -r __GO_LINT_GLOB_ARGS=('--ignore'
-  'coverage:node_modules:public/assets/js/vendor:public/tests/vendor:tmp'
+  'coverage:node_modules:public/assets/js/vendor:public/tests/vendor:public/tests/phantomjs.js:tmp'
   '.' '.js')
 
 _lint_tab_completion() {

--- a/scripts/test.d/browser
+++ b/scripts/test.d/browser
@@ -1,0 +1,28 @@
+#! /usr/bin/env bash
+#
+# Runs browser tests using Phantom JS
+
+declare PHANTOM_POLYFILL_INPUT="$_GO_ROOTDIR/tests/helpers/phantomjs.js"
+declare PHANTOM_POLYFILL_OUTPUT="$_GO_ROOTDIR/public/tests/phantomjs.js"
+
+_test_browser() {
+  local result=0
+  local server_pid
+
+  if [[ ! -f "$PHANTOMJS_POLYFILL_OUTPUT" ]]; then
+    browserify "$PHANTOM_POLYFILL_INPUT" >"$PHANTOM_POLYFILL_OUTPUT"
+  fi
+
+  set -m
+  live-server --no-browser --port=8081 public/ &
+  server_pid="$!"
+
+  mocha-phantomjs 'http://localhost:8081/tests/'
+  result="$?"
+
+  kill -INT "$server_pid"
+  set +m
+  return "$result"
+}
+
+_test_browser "$@"

--- a/tests/helpers/phantomjs.js
+++ b/tests/helpers/phantomjs.js
@@ -1,0 +1,5 @@
+/* eslint-env node, browser */
+'use strict'
+if (window.callPhantom) {
+  require('es6-promise').polyfill()
+}


### PR DESCRIPTION
This ensures that the browser tests are run as part of the Travis CI build. Will likely be absorbed into `./go test` in the near future. A future change will also introduce browser test coverage, likely following the guidance of: [Measuring Client-Side JavaScript Test Coverage With Istanbul](https://blog.engineyard.com/2015/measuring-clientside-javascript-test-coverage-with-istanbul)

This also contains a couple of other minor touch-ups to the existing client-side app code.