### PR TITLE
Pick an unused port to run ./go test browser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - node
 - '4.2'
 script:
-- "./go lint && ./go test --coverage"
+- "./go lint && ./go test --coverage && ./go test browser"
 env:
   matrix:
     secure: "HFeQtlJi3JNCbONSm498Y/EJQ8TO29Te/iD8f5fduacZi7jF0AZUwJBjrIzpmtLhKKvCLRn8BDb11QJrF9c2jZXCX/EouJldMpVHz7pPRVueWk3BaWI6BJpgeCD3SSuMaFTmZUYhhLlrvfVEUWAzxKauKkcQvIxRvjSgC8uyrFYQBbOF8mWLc4AhPgJutCz8HlgMJQF6xO7vblMW5qORQog3vl3445+sAACLqGu7N3CH+fipPa5Yfua0JUJbtf/oQVoMW+eUmMxAGOOS/10mLGTkeN0wIxTYdv10Z1rI9ijAZLUni6p1osdsypOuOzfXSYcPvB3w5OkOrTcO9uHqMxZc9YNblZe7x3Uzg3eMWN7yzl1MyuR/RIsYwjsW+3dSuGxhvznvhzr9mDAhgaBOkUPmb8qyL4r2cXIgVbAEdKiVIAha8XJFlTOT/VWlTvuNJHmvPN2KjpdtNcmkj1pPSaXSAKe738dQhJyzxE1+LJsNIxgAqdMNOvDBWLnBRgMGyZGCLVHflSBs5a6iF6UvlGrS6fpTLyVmNTG4PbnIN1kJm247MNvuKZi5Kj7fc3Yrt01VZPOP5b/00PibvRd7sudH2t0xLNHR1iaFOn2U3rwHSW+NBIhJd2Ms/BibEgOO628wXJnmHA36XEJxVBpgNZp4uL1jUAEvVj6GE4jFnGM="

--- a/public/tests/index.html
+++ b/public/tests/index.html
@@ -8,10 +8,10 @@
   </head>
   <body>
     <div id="mocha"></div>
-    <script src="phantomjs.js"></script>
-    <script src="/app.js"></script>
     <script src="vendor/mocha.js"></script>
     <script src="vendor/chai.js"></script>
+    <script src="phantomjs.js"></script>
+    <script src="/app.js"></script>
     <script>
       chai.should()
       mocha.setup('bdd')

--- a/scripts/test.d/browser
+++ b/scripts/test.d/browser
@@ -2,22 +2,36 @@
 #
 # Runs browser tests using Phantom JS
 
-declare PHANTOM_POLYFILL_INPUT="$_GO_ROOTDIR/tests/helpers/phantomjs.js"
-declare PHANTOM_POLYFILL_OUTPUT="$_GO_ROOTDIR/public/tests/phantomjs.js"
+declare PHANTOM_POLYFILL_INPUT="tests/helpers/phantomjs.js"
+declare PHANTOM_POLYFILL_OUTPUT="public/tests/phantomjs.js"
 
 _test_browser() {
   local result=0
+  local port
   local server_pid
 
   if [[ ! -f "$PHANTOMJS_POLYFILL_OUTPUT" ]]; then
     browserify "$PHANTOM_POLYFILL_INPUT" >"$PHANTOM_POLYFILL_OUTPUT"
   fi
 
+  port="$(tests/helpers/pick-unused-port)"
+  if [[ "$?" -ne '0' ]]; then
+    @go.printf 'Failed to pick an unused port.\n' >&2
+    return 1
+  fi
+
   set -m
-  live-server --no-browser --port=8081 public/ &
+  live-server --no-browser --port=${port} public/ &
+  if [[ "$?" -ne '0' ]]; then
+    @go.printf 'Failed to launch live-server on port %d.\n' "$port" >&2
+    return 1
+  elif [[ -n "$CI" ]]; then
+    # live-server needs a little extra time on Travis.
+    sleep 1
+  fi
   server_pid="$!"
 
-  mocha-phantomjs 'http://localhost:8081/tests/'
+  mocha-phantomjs "http://localhost:${port}/tests/"
   result="$?"
 
   kill -INT "$server_pid"

--- a/tests/helpers/phantomjs.js
+++ b/tests/helpers/phantomjs.js
@@ -1,5 +1,8 @@
 /* eslint-env node, browser */
 'use strict'
+if (typeof window.initMochaPhantomJS === 'function') {
+  window.initMochaPhantomJS()
+}
 if (window.callPhantom) {
   require('es6-promise').polyfill()
 }

--- a/tests/helpers/pick-unused-port
+++ b/tests/helpers/pick-unused-port
@@ -1,0 +1,3 @@
+#! /usr/bin/env node
+'use strict'
+require('.').pickUnusedPort().then(function(port) { console.log(port) } )


### PR DESCRIPTION
Closes #23. Adds the `tests/helpers/pick-unused-port` Node script to facilitate `scripts/test.d/browser` running `live-server` on a port allowed by Travis CI.