### PR TITLE
test: Keep browser test bundle separate

### DIFF
--- a/public/tests/coverage.html
+++ b/public/tests/coverage.html
@@ -18,7 +18,7 @@
       chai.should()
       var expect = chai.expect
     </script>
-    <script src="generated/index.js"></script>
+    <script src="generated/coverage.js"></script>
     <script>
       mocha.checkLeaks();
       mocha.run()

--- a/scripts/test.d/browser
+++ b/scripts/test.d/browser
@@ -7,7 +7,7 @@ declare TEST_BROWSER_HELPER_INPUT='tests/helpers/browser.js'
 
 _test_browser() {
   local result=0
-  local bundle="$TEST_BROWSER_HELPER_DIR/index.js"
+  local bundle
   local url
   local port
   local server_pid
@@ -20,11 +20,13 @@ _test_browser() {
   fi
 
   if [[ "$__COVERAGE_RUN" == 'true' ]]; then
+    bundle="$TEST_BROWSER_HELPER_DIR/coverage.js"
     url='tests/coverage.html'
     browserify -t [ browserify-istanbul --no-defaultIgnore \
       --ignore 'public/tests/vendor/*' --ignore 'public/tests/generated/*' ] \
       "$TEST_BROWSER_HELPER_INPUT" 'public/app.js' public/tests/*.js > "$bundle"
   else
+    bundle="$TEST_BROWSER_HELPER_DIR/index.js"
     url='tests/'
     browserify "$TEST_BROWSER_HELPER_INPUT" >"$bundle"
   fi


### PR DESCRIPTION
Turned out that if I ran `./go test --coverage` before `./go serve --test`, the in-browser Mocha test page would be broken because `public/tests/generated/index.js` would be the incorrect version.