### PR TITLE
Update coverage configuration

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -4,3 +4,9 @@ instrumentation:
   - public/assets/js/vendor/*
   - public/tests/generated/*
   - public/tests/vendor/*
+reporting:
+  print: summary
+  reports:
+  - lcov
+  - html
+  - text

--- a/scripts/test
+++ b/scripts/test
@@ -130,8 +130,7 @@ _test_run_mocha() {
 
 _test_generate_coverage_report() {
   local result=0
-
-  if ! nyc --temp-directory='.coverage' node_modules/.bin/_mocha "$@"; then
+  if ! nyc --reporter='lcov' --temp-directory='.coverage' mocha "$@"; then
     @go.printf 'Backend tests or coverage collection failed.\n' >&2
     result=1
   fi

--- a/scripts/test
+++ b/scripts/test
@@ -134,7 +134,7 @@ _test_generate_coverage_report() {
     @go.printf 'Backend tests or coverage collection failed.\n' >&2
     result=1
   fi
-  if ! @go test browser; then
+  if [[ "${#__test_glob_patterns[@]}" -eq '0' ]] && ! @go test browser; then
     @go.printf 'Browser tests or coverage collection failed.\n' >&2
     result=1
   fi
@@ -191,7 +191,7 @@ _test() {
   fi
 
   if [[ "$1" == '--coverage' ]]; then
-    _test_coverage
+    _test_coverage "$@"
   elif [[ "$1" == '--list' ]]; then
     shift
     @go 'glob' '--trim' "${__GO_TEST_GLOB_ARGS[@]}" "$@"


### PR DESCRIPTION
Now Istanbul will provide a unified summary of both backend and frontend test coverage to the console at the end of `./go test --coverage`. Also, `./go test browser --coverage` will also show a browser-specific summary.

Also allows the collection of coverage for a subset of backend tests.