### PR TITLE
tests/helpers: Extract launchServer, launchAll

### DIFF
--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -1,10 +1,21 @@
 'use strict'
 
 var net = require('net')
+var path = require('path')
 var spawn = require('child_process').spawn
-var testConfig = require('./test-config.json')
 
-module.exports = {
+var rootDir = path.dirname(path.dirname(__dirname))
+var packageInfo = require(path.join(rootDir, 'package.json'))
+var serverMain = path.join(rootDir, packageInfo.main)
+var testConfigPath = path.join(__dirname, 'test-config.json')
+var testConfig = require(testConfigPath)
+
+module.exports = exports = {
+  ROOT_DIR: rootDir,
+  PACKAGE_INFO: packageInfo,
+  SERVER_MAIN: serverMain,
+  TEST_CONFIG_PATH: testConfigPath,
+
   baseConfig: function() {
     return JSON.parse(JSON.stringify(testConfig))
   },
@@ -43,6 +54,52 @@ module.exports = {
           ': ' + err))
       })
     })
+  },
+
+  launchServer: function(port, redisPort) {
+    return new Promise(function(resolve, reject) {
+      var output = { stdout: '', stderr: '' },
+          server,
+          okString = exports.PACKAGE_INFO.name + ' listening on port '
+
+      // TODO: Update test config to allow this port to be used.
+      process.env.URL_POINTERS_PORT = port
+      process.env.URL_POINTERS_REDIS_PORT = redisPort
+      server = spawn('node', [ exports.SERVER_MAIN, exports.TEST_CONFIG_PATH ])
+
+      server.stdout.on('data', function(data) {
+        output.stdout += data
+        if (output.stdout.match(okString)) {
+          setTimeout(resolve, 250, {server: server, port: port, output: output})
+        }
+      })
+      server.stderr.on('data', function(data) {
+        output.stderr += data
+        reject(new Error(output.stderr))
+      })
+      server.on('error', function(err) {
+        err.message = 'failed to start ' + exports.SERVER_MAIN + ': ' +
+          err.message
+        reject(err)
+      })
+    })
+  },
+
+  launchAll: function() {
+    var redisInfo
+    return exports.pickUnusedPort()
+      .then(exports.launchRedis)
+      .then(function(result) {
+        redisInfo = result
+        return exports.pickUnusedPort()
+      })
+      .then(function(port) {
+        return exports.launchServer(port, redisInfo.port)
+      })
+      .then(function(serverInfo) {
+        serverInfo.redis = redisInfo
+        return serverInfo
+      })
   },
 
   killServer: function(server, signal) {

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -1,77 +1,31 @@
 'use strict'
 
-var spawn = require('child_process').spawn
-var path = require('path')
 var helpers = require('./helpers')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
-
-var rootDir = path.dirname(__dirname)
-var packageInfo = require(path.join(rootDir, 'package.json'))
-var scriptPath = path.join(rootDir, packageInfo.main)
-var testConfigPath = path.join(rootDir, 'tests', 'helpers', 'test-config.json')
 
 chai.should()
 chai.use(chaiAsPromised)
 
 describe('Smoke test', function() {
-  var urlpServer, redisServer, launchServer, stdout, stderr, exitCode = 0
+  var serverInfo
 
-  before(function() {
+  beforeEach(function() {
     this.timeout(5000)
-
-    return helpers.pickUnusedPort()
-      .then(helpers.launchRedis)
-      .then(function(redisData) {
-        process.env.URL_POINTERS_REDIS_PORT = redisData.port
-        redisServer = redisData.server
-      })
-  })
-
-  launchServer = function() {
-    return new Promise(function(resolve, reject) {
-      stdout = ''
-      stderr = ''
-
-      urlpServer = spawn('node', [ scriptPath, testConfigPath ])
-
-      urlpServer.stdout.on('data', function(data) {
-        stdout += data
-        if (stdout.match(packageInfo.name + ' listening on port ')) {
-          setTimeout(resolve, 250)
-        }
-      })
-      urlpServer.stderr.on('data', function(data) {
-        stderr += data
-        reject(new Error(stderr))
-      })
-      urlpServer.on('close', function(code) {
-        exitCode = code
-      })
-      urlpServer.on('error', function(err) {
-        err.message = 'failed to start ' + scriptPath + ': ' + err.message
-        reject(err)
-      })
+    return helpers.launchAll().then(function(result) {
+      serverInfo = result
     })
-  }
+  })
 
   afterEach(function() {
-    return helpers.killServer(urlpServer)
+    return helpers.killServer(serverInfo.server).then(function() {
+      return helpers.killServer(serverInfo.redis.server)
+    })
   })
 
-  after(function() {
-    return helpers.killServer(redisServer)
-  })
-
-  describe('launches successfully', function() {
-    beforeEach(function() {
-      this.timeout(5000)
-      return launchServer()
-    })
-
-    it('launches successfully using a well-formed config file', function() {
-      stderr.should.equal('')
-      exitCode.should.equal(0)
-    })
+  it('launches successfully using a well-formed config file', function() {
+    serverInfo.output.stdout.should.have.string(
+      helpers.PACKAGE_INFO.name + ' listening on port ')
+    serverInfo.output.stderr.should.equal('')
   })
 })


### PR DESCRIPTION
`launchAll()` will make it easier to write more system-level/end-to-end tests.