### PR TITLE
auth/test: Implement authenticate using env var

### DIFF
--- a/lib/auth/test.js
+++ b/lib/auth/test.js
@@ -2,12 +2,7 @@
 
 module.exports = {
   config:  {},
-  assemble: assemble,
-  strategyImpl: {
-    authenticate: function() {
-      throw new Error('strategyImpl.authenticate() must be stubbed')
-    }
-  }
+  assemble: assemble
 }
 
 function assemble(passport) {
@@ -19,5 +14,15 @@ function TestStrategy() {
 }
 
 TestStrategy.prototype.authenticate = function(req, options) {
-  module.exports.strategyImpl.authenticate(req, options, this)
+  var userId = process.env.URL_POINTERS_TEST_AUTH
+
+  if (userId === undefined) {
+    throw new Error('URL_POINTERS_TEST_AUTH must be defined')
+  } else if (req.path === '/auth') {
+    this.redirect('/auth/callback')
+  } else if (userId === 'fail') {
+    this.fail()
+  } else {
+    this.success({ id: userId }, options)
+  }
 }

--- a/tests/app-test.js
+++ b/tests/app-test.js
@@ -5,7 +5,6 @@ var assembleApp = appLib.assembleApp
 var sessionParams = appLib.sessionParams
 var Config = require('../lib/config')
 var RedirectDb = require('../lib/redirect-db')
-var testAuth = require('../lib/auth/test')
 var express = require('express')
 var request = require('supertest')
 var chai = require('chai')

--- a/tests/auth-test.js
+++ b/tests/auth-test.js
@@ -163,7 +163,7 @@ describe('auth', function() {
           .to.throw(Error, 'URL_POINTERS_TEST_AUTH must be defined')
       })
 
-      it('uses fake when URL_POINTERS_TEST_AUTH present', function() {
+      it('succeeds when URL_POINTERS_TEST_AUTH present', function() {
         testAuth.assemble(passport)
         strategy = passport.use.getCall(0).args[0]
         strategy.success = sinon.spy()


### PR DESCRIPTION
Realized it would be handy to have the test authentication implementation controlled via the `URL_POINTERS_TEST_AUTH` environment variable. Makes stubbing the `TestStrategy.authenticate` method superfluous.