### PR TITLE
test browser: Switch to mocha-phantomjs-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "istanbul": "^0.4.5",
     "live-server": "^1.2.0",
     "mocha": "^3.3.0",
-    "mocha-phantomjs": "^4.1.0",
+    "mocha-phantomjs-core": "^2.1.1",
     "nyc": "^10.3.2",
     "sinon": "^2.1.0",
     "supertest": "^3.0.0"

--- a/scripts/test.d/browser
+++ b/scripts/test.d/browser
@@ -73,7 +73,11 @@ _test_browser_run_tests() {
   fi
   server_pid="$!"
 
-  mocha-phantomjs "$test_server_url" --hooks 'tests/helpers/phantomjs.js'
+  phantomjs node_modules/mocha-phantomjs-core/mocha-phantomjs-core.js \
+    "$test_server_url" 'spec' "{ \
+      \"hooks\": \"$_GO_ROOTDIR/tests/helpers/phantomjs.js\",\
+      \"useColors\": true\
+    }"
   result="$?"
   kill -INT "$server_pid"
   set +m


### PR DESCRIPTION
This will require that the user have phantomjs already installed; will update scripts/setup to ensure this in a future commit. That said, this should speed up Travis builds slightly by allowing it to use its default phantomjs rather than having to download the version used by mocha-phantomjs.