### PR TITLE
auth/test: Enable sessions via redis

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,14 @@ var RedisClient = require('./lib/redis-client')
 var redisClientOptions = {}
 var session = require('express-session')
 var RedisStore = require('connect-redis')(session)
+var redisStoreOptions = {}
 var urlPointers = require('./lib')
 var morgan = require('morgan')
 var logger = console
 
 if (config.REDIS_PORT !== undefined) {
   redisClientOptions.port = config.REDIS_PORT
+  redisStoreOptions.port = config.REDIS_PORT
 }
 
 var redisClient = redis.createClient(redisClientOptions)
@@ -27,7 +29,7 @@ urlPointers.assembleApp(
   app,
   new RedirectDb(new RedisClient(redisClient, logger)),
   logger,
-  new RedisStore,
+  new RedisStore(redisStoreOptions),
   config)
 
 var server = app.listen(config.PORT)

--- a/lib/auth/test.js
+++ b/lib/auth/test.js
@@ -1,20 +1,25 @@
 'use strict'
 
+var auth = require('../auth')
+
 module.exports = {
   config:  {},
   assemble: assemble
 }
 
-function assemble(passport) {
-  passport.use(new TestStrategy)
+function assemble(passport, redirectDb, config) {
+  passport.use(new TestStrategy(redirectDb, config))
 }
 
-function TestStrategy() {
+function TestStrategy(redirectDb, config) {
   this.name = 'test'
+  this.redirectDb = redirectDb
+  this.config = config
 }
 
 TestStrategy.prototype.authenticate = function(req, options) {
-  var userId = process.env.URL_POINTERS_TEST_AUTH
+  var userId = process.env.URL_POINTERS_TEST_AUTH,
+      done = () => this.success({ id: userId }, options)
 
   if (userId === undefined) {
     throw new Error('URL_POINTERS_TEST_AUTH must be defined')
@@ -22,7 +27,18 @@ TestStrategy.prototype.authenticate = function(req, options) {
     this.redirect('/auth/callback')
   } else if (userId === 'fail') {
     this.fail()
+  } else if (req.path === '/auth/callback') {
+    // Return a Promise from this case for testing
+    return new Promise((resolve, reject) => {
+      auth.verify(this.redirectDb, this.config, [ userId ], (err, result) => {
+        if (err || result === false) {
+          this.fail()
+          return reject(err || 'unknown user: ' + userId)
+        }
+        resolve(done())
+      })
+    })
   } else {
-    this.success({ id: userId }, options)
+    done()
   }
 }

--- a/tests/app-test.js
+++ b/tests/app-test.js
@@ -22,6 +22,8 @@ describe('assembleApp', function() {
 
   before(function() {
     redirectDb = new RedirectDb
+    sinon.stub(redirectDb, 'findOrCreateUser')
+      .returns(Promise.resolve({ id: 'mbland@acm.org' }))
     sinon.stub(redirectDb, 'findUser')
       .returns(Promise.resolve({ id: 'mbland@acm.org' }))
 


### PR DESCRIPTION
Initial attempts to get the end-to-end test working were thwarted because the previous `TestStrategy` didn't actually cause a session to get created, leading to an endless redirect loop. These changes make the test authentication strategy more robust, and enable the initial end-to-end test to function successfully.

Also started introducing arrow functions into the code base. I may go through and update all functions to be arrow functions in a future commit.