### PR TITLE
tests/helpers: Launch with dynamic port, add tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict'
 
-var config = require('./lib/config').fromFile(
-      process.argv[2] || process.env.URL_POINTERS_CONFIG_PATH, console)
+var Config = require('./lib/config')
+var configFile = process.argv[2] || process.env.URL_POINTERS_CONFIG_PATH
+var config = configFile ? Config.fromFile(configFile, console) : new Config({})
 
 var packageInfo = require('./package.json')
 var express = require('express')

--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -56,21 +56,28 @@ module.exports = exports = {
     })
   },
 
-  launchServer: function(port, redisPort) {
+  launchServer: function(port, redisPort, configPath) {
     return new Promise(function(resolve, reject) {
-      var output = { stdout: '', stderr: '' },
+      var args = [ exports.SERVER_MAIN ],
+          output = { stdout: '', stderr: '' },
           server,
           okString = exports.PACKAGE_INFO.name + ' listening on port '
 
-      // TODO: Update test config to allow this port to be used.
+      if (configPath) {
+        args.push(configPath)
+      } else if (configPath !== null && !process.env.URL_POINTERS_CONFIG_PATH) {
+        args.push(path.join(__dirname, 'system-test-config.json'))
+      }
+
       process.env.URL_POINTERS_PORT = port
       process.env.URL_POINTERS_REDIS_PORT = redisPort
-      server = spawn('node', [ exports.SERVER_MAIN, exports.TEST_CONFIG_PATH ])
+      process.env.URL_POINTERS_TEST_AUTH = 'mbland@acm.org'
+      server = spawn('node', args)
 
       server.stdout.on('data', function(data) {
         output.stdout += data
         if (output.stdout.match(okString)) {
-          setTimeout(resolve, 250, {server: server, port: port, output: output})
+          resolve({server: server, port: port, output: output})
         }
       })
       server.stderr.on('data', function(data) {
@@ -85,25 +92,38 @@ module.exports = exports = {
     })
   },
 
-  launchAll: function() {
+  launchAll: function(configPath) {
     var redisInfo
     return exports.pickUnusedPort()
       .then(exports.launchRedis)
+      .catch(function(err) {
+        err.message = 'Failed to launch redis server: ' + err.message
+        return Promise.reject(err)
+      })
       .then(function(result) {
         redisInfo = result
         return exports.pickUnusedPort()
-      })
-      .then(function(port) {
-        return exports.launchServer(port, redisInfo.port)
-      })
-      .then(function(serverInfo) {
-        serverInfo.redis = redisInfo
-        return serverInfo
+          .then(function(port) {
+            return exports.launchServer(port, redisInfo.port, configPath)
+          })
+          .catch(function(err) {
+            err.message = 'Failed to launch server: ' + err.message
+            return exports.killServer(redisInfo.server).then(function() {
+              return Promise.reject(err)
+            })
+          })
+          .then(function(serverInfo) {
+            serverInfo.redis = redisInfo
+            return serverInfo
+          })
       })
   },
 
   killServer: function(server, signal) {
     return new Promise(function(resolve) {
+      if (!server) {
+        return
+      }
       signal = signal || 'SIGTERM'
       server.on('exit', function() {
         resolve()

--- a/tests/helpers/system-test-config.json
+++ b/tests/helpers/system-test-config.json
@@ -1,0 +1,8 @@
+{
+  "AUTH_PROVIDERS": [ "test" ],
+  "SESSION_SECRET": "<session secret>",
+  "SESSION_MAX_AGE": 3600,
+  "users": [
+    "mbland@acm.org"
+  ]
+}

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var path = require('path')
 var helpers = require('./helpers')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
@@ -8,24 +9,52 @@ chai.should()
 chai.use(chaiAsPromised)
 
 describe('Smoke test', function() {
-  var serverInfo
+  var testConfig = path.join(__dirname, 'helpers', 'system-test-config.json'),
+      doLaunch,
+      serverInfo
+
+  this.timeout(5000)
 
   beforeEach(function() {
-    this.timeout(5000)
-    return helpers.launchAll().then(function(result) {
-      serverInfo = result
-    })
+    serverInfo = null
+    delete process.env.URL_POINTERS_CONFIG_PATH
   })
 
   afterEach(function() {
+    delete process.env.URL_POINTERS_CONFIG_PATH
+    if (serverInfo === null) {
+      return
+    }
     return helpers.killServer(serverInfo.server).then(function() {
       return helpers.killServer(serverInfo.redis.server)
     })
   })
 
-  it('launches successfully using a well-formed config file', function() {
-    serverInfo.output.stdout.should.have.string(
-      helpers.PACKAGE_INFO.name + ' listening on port ')
-    serverInfo.output.stderr.should.equal('')
+  doLaunch = function(configPath) {
+    return helpers.launchAll(configPath).should.be.fulfilled
+      .then(function(result) {
+        serverInfo = result
+        serverInfo.output.stdout.should.have.string(
+          helpers.PACKAGE_INFO.name + ' listening on port ')
+        serverInfo.output.stderr.should.equal('')
+      })
+  }
+
+  it('launches using the default system-test-config.json', function() {
+    return doLaunch()
+  })
+
+  it('launches using a config path command line argument', function() {
+    return doLaunch(testConfig)
+  })
+
+  it('launches using URL_POINTERS_CONFIG_PATH', function() {
+    process.env.URL_POINTERS_CONFIG_PATH = testConfig
+    return doLaunch()
+  })
+
+  it('fails to launch due to missing variables', function() {
+    return doLaunch(null).should.be.rejectedWith(Error,
+      'missing AUTH_PROVIDERS')
   })
 })


### PR DESCRIPTION
The test server can now launch using a dynamically-selected port, rather than always defaulting to 3000.

The call to `setTimeout()` was vestigial from trying to resolve Travis build failures in #15; should've been removed when the test suite timeout was increased to 5000ms in #18.

Also added smoke tests to cover the different ways of passing a config file to the main process, as well as to check startup failure due to a bad configuration. The environment variable-only branch isn't fully checked, as it's currently not possible to specify the entire configuration that way, though that may change eventually.