### PR TITLE
end-to-end: Refactor for Chrome, focus new link

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -201,6 +201,14 @@
         var result = urlp.getTemplate(resultData.template)
         result.innerHTML = resultData.message
         return urlp.flashElement(resultFlash, result.outerHTML)
+          .then(function() {
+            // TODO(mbland): Add a unit test for this (currently covered by
+            // tests/end-to-end.js).
+            var link = resultFlash.getElementsByTagName('A')[0]
+            if (link) {
+              link.focus()
+            }
+          })
       })
     return false
   }

--- a/public/tests/redirect-target.html
+++ b/public/tests/redirect-target.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>End-to-End test redirect target page</title>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="vendor/mocha.css" />
+  </head>
+  <body>
+    <p>This is the redirect target page for end-to-end tests.</p>
+  </body>
+</html>

--- a/tests/end-to-end.js
+++ b/tests/end-to-end.js
@@ -5,12 +5,13 @@ var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
 var test = require('selenium-webdriver/testing')
 var webdriver = require('selenium-webdriver')
+var Key = webdriver.Key
 
 chai.should()
 chai.use(chaiAsPromised)
 
 test.describe('End-to-end test', function() {
-  var driver, serverInfo, url
+  var driver, serverInfo, url, targetLocation, activeElement
 
   this.timeout(5000)
 
@@ -22,6 +23,7 @@ test.describe('End-to-end test', function() {
     return helpers.launchAll().then(function(result) {
       serverInfo = result
       url = 'http://localhost:' + serverInfo.port + '/'
+      targetLocation = url + 'tests/redirect-target.html'
     })
   })
 
@@ -31,13 +33,25 @@ test.describe('End-to-end test', function() {
     })
   })
 
-  test.it('WORK IN PROGRESS — creates a new short link', function() {
-    driver.get(url)
-    driver.findElement(webdriver.By.css('*[data-name=url]')).sendKeys('foo')
-    driver.findElement(webdriver.By.css('*[data-name=location]'))
-      .sendKeys('https://mike-bland.com/')
-    driver.findElement(webdriver.By.css('*[data-name=submit]')).click()
-    driver.get(url + 'foo')
+  test.afterEach(function() {
     driver.quit()
+  })
+
+  activeElement = function() {
+    return driver.switchTo().activeElement()
+  }
+
+  test.it('creates a new short link', function() {
+    driver.get(url)
+    activeElement().sendKeys('foo' + Key.TAB)
+    activeElement().sendKeys(targetLocation + Key.TAB)
+    activeElement().sendKeys(Key.ENTER)
+    driver.wait(function() {
+      return activeElement().getText().then(function(text) {
+        return text === url + 'foo'
+      })
+    }, 1250)
+    activeElement().click()
+    driver.getCurrentUrl().should.become(targetLocation)
   })
 })


### PR DESCRIPTION
Will get it to work on PhantomJS and Safari later, as well as add a unit test for the new behavior whereby the newly-created link is focused. (There's a known issue and fix for the Firefox `sendText()` behavior that hasn't yet made its way into selenium-webdriver.)

Also grateful for the following articles to light my way a little better:

- https://team.goodeggs.com/getting-started-with-selenium-webdriver-for-node-js-f262a00c52e1
- http://www.techinsight.io/review/devops-and-automation/browser-automation-using-selenium-webdriver-and-nodejs/