### PR TITLE
setup: Install PhantomJS if missing; use for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 - "sh -e /etc/init.d/xvfb start"
 
 script:
-- "./go lint && ./go test --coverage && ./go test end-to-end"
+- "./go setup"
 
 env:
   matrix:

--- a/scripts/setup
+++ b/scripts/setup
@@ -9,16 +9,29 @@ urlp.check_for_required_programs() {
   fi
 }
 
+urlp.install_required_tools() {
+  if ! command -v phantomjs >/dev/null; then
+    npm install phantomjs-prebuilt
+  fi
+}
+
 urlp.setup() {
   @go.critical_section_begin
 
   export PATH="node_modules/.bin:$PATH"
   export MOCHA_COLORS='true'
+  export FORCE_COLOR='true'
+
   urlp.check_for_required_programs
-  @go.log_command npm install
+  urlp.install_required_tools
+
+  if [[ ! -d "$_GO_ROOTDIR/node_modules" ]]; then
+    @go.log_command npm install
+  fi
   @go.log_command @go lint
-  @go.log_command @go test
-  @go.log_command @go test browser
+
+  # --coverage will run both the backend and browser tests.
+  __SETUP_RUN='true' @go.log_command @go test --coverage
   SELENIUM_BROWSER=phantomjs @go.log_command @go test end-to-end
   @go.critical_section_end
 }

--- a/scripts/test
+++ b/scripts/test
@@ -5,6 +5,12 @@
 # Usage:
 #   {{go}} {{cmd}} [--coverage|--edit|--list|--mocha-help] [<glob>...]
 #
+#   To run browser tests only:
+#   {{go}} {{cmd}} browser [--coverage]
+#
+#   To run end-to-end tests:
+#   {{go}} {{cmd}} end-to-end
+#
 # Options:
 #   --coverage    Collect test coverage data using nyc/istanbul
 #   --edit        Open matching test files using `{{go}} edit`
@@ -14,8 +20,13 @@
 # In addition to the above option flags, all underlying mocha flags are
 # available.
 #
-# Without <glob> arguments, runs (or edits, or lists) all tests. With one or
-# more <glob> arguments, only runs tests matching 'tests/<glob>-test.js'.
+# Without <glob> arguments, runs (or edits, or lists) all backend tests from
+# 'tests/'. With one or more <glob> arguments, only runs tests matching
+# 'tests/<glob>-test.js'.
+#
+# With the '--coverage' flag, it will also run the browser tests using
+# PhantomJS. To run browser tests only, without coverage, run `{{go}} {{cmd}}
+# browser`.
 #
 # The '--coverage' flag will place its output in a directory called 'coverage'.
 # An HTML report will be available at 'coverage/lcov-report/index.html'.
@@ -157,12 +168,12 @@ _test_coverage() {
 
   if [[ ! -r "$report_path" ]]; then
     return 1
-  elif [[ -z "$CI" ]]; then
+  elif [[ -z "$CI" && -z "$__SETUP_RUN" ]]; then
     echo "Report saved as: $report_path"
     if command -v open >/dev/null; then
       open "$report_path"
     fi
-  else
+  elif [[ -n "$CI" ]]; then
     if ! coveralls < "$lcov_info_path"; then
       echo "Failed to send coverage report to Coveralls." >&2
       return 1

--- a/scripts/test.d/end-to-end
+++ b/scripts/test.d/end-to-end
@@ -1,6 +1,12 @@
 #! /usr/bin/env bash
 #
-# Runs end-to-end tests using Selenium and Mocha
+# Runs end-to-end tests using Selenium-WebDriver and Mocha
+#
+# Usage:
+#   [SELENIUM_BROWSER=<browser>] {{go}} {{cmd}}
+#
+# Where:
+#   <browser>  Browser to use, e.g. chrome (default), firefox, phantomjs, safari
 
 _test_end_to_end() {
   local node_version


### PR DESCRIPTION
Since `./go setup` should do everything necessary to set up the environment and run the tests, it seems like a good idea to run it as the Travis CI test command. Also updated some of the help text for `./go test` and `./go test end-to-end`.