### PR TITLE
scripts: Revamp `./go test`, `./go setup`

### DIFF
--- a/scripts/lib/coverage
+++ b/scripts/lib/coverage
@@ -1,0 +1,44 @@
+#! /usr/bin/env bash
+#
+# Coverage report generator
+
+export URLP_COVERAGE_DATADIR="${URLP_COVERAGE_DATADIR:-$_GO_ROOTDIR/.coverage}"
+
+urlp.generate_coverage_report() {
+  local report_path="${_GO_ROOTDIR}/coverage/lcov-report/index.html"
+
+  rm -f "$report_path"
+
+  if ! istanbul report --root "$URLP_COVERAGE_DATADIR" --include '*.json'; then
+    @go.printf 'Failed to generate coverage report.\n' >&2
+    return 1
+  elif [[ -n "$CI" ]]; then
+    urlp.send_coverage_report
+  elif command -v open >/dev/null; then
+    open "$report_path"
+  fi
+}
+
+urlp.send_coverage_report() {
+  local lcov_info_path="${_GO_ROOTDIR}/coverage/lcov.info"
+  local github_repo="$(git config remote.origin.url)"
+
+  github_repo="${github_repo##*[@/]github.com[:/]}"
+  github_repo="${github_repo%.git}"
+
+  if ! coveralls < "$lcov_info_path"; then
+    echo "Failed to send coverage report to Coveralls." >&2
+    return 1
+  fi
+  printf 'Coverage report sent to Coveralls: %s\n' \
+    "https://coveralls.io/github/${github_repo}"
+
+  if [[ -n "$CODECLIMATE_REPO_TOKEN" ]]; then
+    if ! codeclimate-test-reporter < "$lcov_info_path"; then
+      echo 'Failed to send report to Code Climate.' >&2
+      return 1
+    fi
+    printf 'Report sent to Code Climate: %s\n' \
+      "https://codeclimate.com/github/${github_repo}"
+  fi
+}

--- a/scripts/setup
+++ b/scripts/setup
@@ -2,7 +2,7 @@
 #
 # Runs first-time setup commands for a freshly-cloned repository
 
-urlp.check_for_required_programs() {
+urlp.check_for_prerequisite_tools() {
   if ! command -v node >/dev/null; then
     printf 'Please install Node.js before continuing.\n' >&2
     return 1
@@ -22,17 +22,14 @@ urlp.setup() {
   export MOCHA_COLORS='true'
   export FORCE_COLOR='true'
 
-  urlp.check_for_required_programs
-  urlp.install_required_tools
+  urlp.check_for_prerequisite_tools
 
   if [[ ! -d "$_GO_ROOTDIR/node_modules" ]]; then
     @go.log_command npm install
   fi
+  urlp.install_required_tools
   @go.log_command @go lint
-
-  # --coverage will run both the backend and browser tests.
-  __SETUP_RUN='true' @go.log_command @go test --coverage
-  SELENIUM_BROWSER=phantomjs @go.log_command @go test end-to-end
+  @go.log_command @go test --coverage
   @go.critical_section_end
 }
 

--- a/scripts/test
+++ b/scripts/test
@@ -1,71 +1,15 @@
 #! /bin/bash
 # 
-# Run automated tests
+# Run all automated tests
 #
 # Usage:
-#   {{go}} {{cmd}} [--coverage|--edit|--list|--mocha-help] [<glob>...]
-#
-#   To run browser tests only:
-#   {{go}} {{cmd}} browser [--coverage]
-#
-#   To run end-to-end tests:
-#   {{go}} {{cmd}} end-to-end
+#   {{go}} {{cmd}} [--coverage]
 #
 # Options:
 #   --coverage    Collect test coverage data using nyc/istanbul
-#   --edit        Open matching test files using `{{go}} edit`
-#   --list        List test suite names without executing them
-#   --mocha-help  Show output from `mocha --help`
-#
-# In addition to the above option flags, all underlying mocha flags are
-# available.
-#
-# Without <glob> arguments, runs (or edits, or lists) all backend tests from
-# 'tests/'. With one or more <glob> arguments, only runs tests matching
-# 'tests/<glob>-test.js'.
-#
-# With the '--coverage' flag, it will also run the browser tests using
-# PhantomJS. To run browser tests only, without coverage, run `{{go}} {{cmd}}
-# browser`.
 #
 # The '--coverage' flag will place its output in a directory called 'coverage'.
 # An HTML report will be available at 'coverage/lcov-report/index.html'.
-
-declare -r __GO_TEST_FLAGS=('--coverage' '--edit' '--list' '--mocha-help')
-declare -r __GO_TEST_GLOB_ARGS=('tests' '-test.js')
-declare -r __GO_MOCHA_FLAGS_WITH_ARGS=(
-  '-O' '--reporter-options'
-  '-R' '--reporter'
-  '-g' '--grep'
-  '-f' '--fgrep'
-  '-r' '--require'
-  '-s' '--slow'
-  '-t' '--timeout'
-  '-u' '--ui'
-  '-w' '--watch'
-  '--compilers'
-  '--globals'
-  '--opts'
-  '--retries'
-  '--watch-extensions'
-)
-
-declare GITHUB_REPO="$(git config remote.origin.url)"
-GITHUB_REPO="${GITHUB_REPO##*[@/]github.com[:/]}"
-GITHUB_REPO="${GITHUB_REPO%.git}"
-
-_test_mocha_flags() {
-  local flag_line_pattern='^ *-'
-  local line
-
-  mocha -h | while read -r line; do
-    if [[ "$line" =~ $flag_line_pattern ]]; then
-      local line="${line#*-}"
-      line="${line%%[ <]*}"
-      echo "-${line/,/}"
-    fi
-  done
-}
 
 _test_tab_completion() {
   local word_index="$1"
@@ -74,147 +18,46 @@ _test_tab_completion() {
   local word="${args[$word_index]}"
 
   if [[ "$word_index" -eq '0' ]]; then
-    if [[ "${1:0:1}" == '-' ]]; then
-      @go.compgen -W "${__GO_TEST_FLAGS[*]} $(_test_mocha_flags)" -- "$1"
-      return
-    else
-      echo '-'
-    fi
+    @go.compgen -W '--coverage' -- "$1"
   fi
-  @go 'glob' '--complete' "$((word_index + ${#__GO_TEST_GLOB_ARGS[@]}))" \
-    "${__GO_TEST_GLOB_ARGS[@]}" "${args[@]}"
-}
-
-_test_is_mocha_flag_with_arg() {
-  local i
-
-  for ((i=0; i != "${#__GO_MOCHA_FLAGS_WITH_ARGS[@]}"; ++i)); do
-    if [[ "${__GO_MOCHA_FLAGS_WITH_ARGS[$i]}" == "$1" ]]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
-_test_parse_command_line() {
-  while [[ "$#" -ne 0 ]]; do
-    if [[ "${1:0:1}" == '-' ]]; then
-      if [[ "${#glob_patterns[@]}" -ne '0' ]]; then
-        printf "Please specify all flags before glob patterns." >&2
-        return 1
-      fi
-
-      __test_mocha_flags+=("$1")
-      if _test_is_mocha_flag_with_arg "$1"; then
-        __test_mocha_flags+=("$2")
-        shift
-      fi
-    else
-      __test_glob_patterns+=("$1")
-    fi
-    shift
-  done
-}
-
-_test_run_mocha() {
-  local __test_mocha_flags=()
-  local __test_glob_patterns=()
-  local help_flag_pattern='-(h|-help)'
-  local argv=()
-
-  _test_parse_command_line "$@"
-
-  if [[ "${__test_mocha_flags[*]}" =~ $help_flag_pattern ]]; then
-    mocha -h
-    return
-  fi
-
-  argv=("${__test_mocha_flags[@]}"
-    $(@go 'glob' "${__GO_TEST_GLOB_ARGS[@]}" "${__test_glob_patterns[@]}"))
-
-  if [[ "$__COVERAGE_RUN" == 'true' ]]; then
-    _test_generate_coverage_report "${argv[@]}"
-  else
-    mocha "${argv[@]}"
-  fi
-}
-
-_test_generate_coverage_report() {
-  local result=0
-  if ! nyc --reporter='lcov' --temp-directory='.coverage' mocha "$@"; then
-    @go.printf 'Backend tests or coverage collection failed.\n' >&2
-    result=1
-  fi
-  if [[ "${#__test_glob_patterns[@]}" -eq '0' ]] && ! @go test browser; then
-    @go.printf 'Browser tests or coverage collection failed.\n' >&2
-    result=1
-  fi
-  if ! istanbul report --root '.coverage' --include '*.json'; then
-    @go.printf 'Failed to generate coverage report.\n' >&2
-    result=1
-  fi
-
-  return "$result"
-}
-
-_test_coverage() {
-  local report_path="${_GO_ROOTDIR}/coverage/lcov-report/index.html"
-  local lcov_info_path="${_GO_ROOTDIR}/coverage/lcov.info"
-  local result=0
-
-  rm -f "$report_path"
-  __COVERAGE_RUN='true' _test_run_mocha "${@:2}"
-  result="$?"
-
-  if [[ ! -r "$report_path" ]]; then
-    return 1
-  elif [[ -z "$CI" && -z "$__SETUP_RUN" ]]; then
-    echo "Report saved as: $report_path"
-    if command -v open >/dev/null; then
-      open "$report_path"
-    fi
-  elif [[ -n "$CI" ]]; then
-    if ! coveralls < "$lcov_info_path"; then
-      echo "Failed to send coverage report to Coveralls." >&2
-      return 1
-    fi
-    printf 'Coverage report sent to Coveralls: %s\n' \
-      "https://coveralls.io/github/${GITHUB_REPO}"
-
-    if [[ -n "$CODECLIMATE_REPO_TOKEN" ]]; then
-      if ! codeclimate-test-reporter < "$lcov_info_path"; then
-        echo 'Failed to send report to Code Climate.' >&2
-        return 1
-      fi
-      printf 'Report sent to Code Climate: %s\n' \
-        "https://codeclimate.com/github/${GITHUB_REPO}"
-    fi
-  fi
-  return "$result"
 }
 
 _test() {
-  if [[ "$1" == '--complete' ]]; then
+  local coverage_run
+  local result
+
+  case "$1" in
+  --complete)
     # Tab completions
     shift
     _test_tab_completion "$@"
     return
-  fi
+    ;;
+  --coverage)
+    coverage_run='true'
+    . "$_GO_USE_MODULES" 'coverage'
+    ;;
+  esac
+
+  export __TEST_ALL='true'
 
   if [[ "$1" == '--coverage' ]]; then
-    _test_coverage "$@"
-  elif [[ "$1" == '--list' ]]; then
-    shift
-    @go 'glob' '--trim' "${__GO_TEST_GLOB_ARGS[@]}" "$@"
-  elif [[ "$1" == '--edit' ]]; then
-    shift
-    local tests=($(@go 'glob' "${__GO_TEST_GLOB_ARGS[@]}" "$@"))
-    @go 'edit' "${tests[@]}"
-  elif [[ "$1" == '--mocha-help' ]]; then
-    mocha -h
+    @go test backend --coverage && @go test browser --coverage
   else
-    _test_run_mocha "$@"
+    @go test backend && @go test browser
   fi
+
+  result="$?"
+
+  if [[ "$result" -eq '0' ]]; then
+    @go test end-to-end
+    result="$?"
+  fi
+
+  if [[ -n "$coverage_run" ]] && ! urlp.generate_coverage_report; then
+    result='1'
+  fi
+  return "$result"
 }
 
 _test "$@"

--- a/scripts/test.d/backend
+++ b/scripts/test.d/backend
@@ -1,0 +1,163 @@
+#! /bin/bash
+# 
+# Run automated backend tests
+#
+# Usage:
+#   {{go}} {{cmd}} [--coverage|--edit|--list|--mocha-help] [<glob>...]
+#
+# Options:
+#   --coverage    Collect test coverage data using nyc/istanbul
+#   --edit        Open matching test files using `{{go}} edit`
+#   --list        List test suite names without executing them
+#   --mocha-help  Show output from `mocha --help`
+#
+# In addition to the above option flags, all underlying mocha flags are
+# available.
+#
+# Without <glob> arguments, runs (or edits, or lists) all backend tests from
+# 'tests/'. With one or more <glob> arguments, only runs tests matching
+# 'tests/<glob>-test.js'.
+#
+# The '--coverage' flag will place its output in a directory called 'coverage'.
+# An HTML report will be available at 'coverage/lcov-report/index.html'.
+
+declare -r __GO_TEST_FLAGS=('--coverage' '--edit' '--list' '--mocha-help')
+declare -r __GO_TEST_GLOB_ARGS=('tests' '-test.js')
+declare -r __GO_MOCHA_FLAGS_WITH_ARGS=(
+  '-O' '--reporter-options'
+  '-R' '--reporter'
+  '-g' '--grep'
+  '-f' '--fgrep'
+  '-r' '--require'
+  '-s' '--slow'
+  '-t' '--timeout'
+  '-u' '--ui'
+  '-w' '--watch'
+  '--compilers'
+  '--globals'
+  '--opts'
+  '--retries'
+  '--watch-extensions'
+)
+
+_test_mocha_flags() {
+  local flag_line_pattern='^ *-'
+  local line
+
+  mocha -h | while read -r line; do
+    if [[ "$line" =~ $flag_line_pattern ]]; then
+      local line="${line#*-}"
+      line="${line%%[ <]*}"
+      echo "-${line/,/}"
+    fi
+  done
+}
+
+_test_tab_completion() {
+  local word_index="$1"
+  shift
+  local args=("$@")
+  local word="${args[$word_index]}"
+
+  if [[ "$word_index" -eq '0' ]]; then
+    if [[ "${1:0:1}" == '-' ]]; then
+      @go.compgen -W "${__GO_TEST_FLAGS[*]} $(_test_mocha_flags)" -- "$1"
+      return
+    else
+      echo '-'
+    fi
+  fi
+  @go 'glob' '--complete' "$((word_index + ${#__GO_TEST_GLOB_ARGS[@]}))" \
+    "${__GO_TEST_GLOB_ARGS[@]}" "${args[@]}"
+}
+
+_test_is_mocha_flag_with_arg() {
+  local i
+
+  for ((i=0; i != "${#__GO_MOCHA_FLAGS_WITH_ARGS[@]}"; ++i)); do
+    if [[ "${__GO_MOCHA_FLAGS_WITH_ARGS[$i]}" == "$1" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+_test_parse_command_line() {
+  while [[ "$#" -ne 0 ]]; do
+    if [[ "${1:0:1}" == '-' ]]; then
+      if [[ "${#glob_patterns[@]}" -ne '0' ]]; then
+        printf "Please specify all flags before glob patterns." >&2
+        return 1
+      fi
+
+      __test_mocha_flags+=("$1")
+      if _test_is_mocha_flag_with_arg "$1"; then
+        __test_mocha_flags+=("$2")
+        shift
+      fi
+    else
+      __test_glob_patterns+=("$1")
+    fi
+    shift
+  done
+}
+
+_test_run_mocha() {
+  local __test_mocha_flags=()
+  local __test_glob_patterns=()
+  local help_flag_pattern='-(h|-help)'
+  local argv=()
+
+  _test_parse_command_line "$@"
+
+  if [[ "${__test_mocha_flags[*]}" =~ $help_flag_pattern ]]; then
+    mocha -h
+    return
+  fi
+
+  argv=("${__test_mocha_flags[@]}"
+    $(@go 'glob' "${__GO_TEST_GLOB_ARGS[@]}" "${__test_glob_patterns[@]}"))
+
+  if [[ "$__coverage_run" == 'true' ]]; then
+    _test_generate_coverage_report "${argv[@]}"
+  else
+    mocha "${argv[@]}"
+  fi
+}
+
+_test_generate_coverage_report() {
+  . "$_GO_USE_MODULES" 'coverage'
+
+  if ! nyc --reporter='lcov' --temp-directory='.coverage' mocha "$@"; then
+    @go.printf 'Backend tests or coverage collection failed.\n' >&2
+    return 1
+  elif [[ -z "$__TEST_ALL" ]]; then
+    urlp.generate_coverage_report
+  fi
+}
+
+_test() {
+  if [[ "$1" == '--complete' ]]; then
+    # Tab completions
+    shift
+    _test_tab_completion "$@"
+    return
+  fi
+
+  if [[ "$1" == '--coverage' ]]; then
+    __coverage_run='true' _test_run_mocha "${@:2}"
+  elif [[ "$1" == '--list' ]]; then
+    shift
+    @go 'glob' '--trim' "${__GO_TEST_GLOB_ARGS[@]}" "$@"
+  elif [[ "$1" == '--edit' ]]; then
+    shift
+    local tests=($(@go 'glob' "${__GO_TEST_GLOB_ARGS[@]}" "$@"))
+    @go 'edit' "${tests[@]}"
+  elif [[ "$1" == '--mocha-help' ]]; then
+    mocha -h
+  else
+    _test_run_mocha "$@"
+  fi
+}
+
+_test "$@"

--- a/scripts/test.d/browser
+++ b/scripts/test.d/browser
@@ -91,14 +91,14 @@ _test_browser_generate_coverage_report() {
   if ! istanbul report --root '.coverage' --include 'browser.json'; then
     @go.printf 'Failed to generate coverage report.\n' >&2
     return 1
-  elif [[ -z "$__COVERAGE_RUN" ]] && command -v open >/dev/null; then
+  elif [[ -z "$__TEST_ALL" ]] && command -v open >/dev/null; then
     # Pop open the report when invoked with --coverage, not via parent script.
     open "$report_path"
   fi
 }
 
 _test_browser() {
-  local __coverage_run="$__COVERAGE_RUN"
+  local __coverage_run
   local result=0
 
   case "$1" in
@@ -110,6 +110,10 @@ _test_browser() {
     ;;
   --coverage)
     __coverage_run='true'
+    . "$_GO_USE_MODULES" 'coverage'
+    if [[ -z "$__TEST_ALL" ]]; then
+      rm "$URLP_COVERAGE_DATADIR"/*.json
+    fi
     ;;
   '')
     ;;
@@ -119,12 +123,12 @@ _test_browser() {
     ;;
   esac
 
-  _test_browser_create_bundle
-  _test_browser_run_tests
+  _test_browser_create_bundle && _test_browser_run_tests
   result="$?"
 
-  if [[ -n "$__coverage_run" ]]; then
-    _test_browser_generate_coverage_report
+  if [[ -n "$__coverage_run" && -z "$__TEST_ALL" ]] &&
+    ! urlp.generate_coverage_report; then
+    result='1'
   fi
   return "$result"
 }

--- a/scripts/test.d/end-to-end
+++ b/scripts/test.d/end-to-end
@@ -7,6 +7,8 @@
 #
 # Where:
 #   <browser>  Browser to use, e.g. chrome (default), firefox, phantomjs, safari
+#
+# Note the the end-to-end tests DO NOT collect coverage.
 
 _test_end_to_end() {
   local node_version


### PR DESCRIPTION
The scripts are now a bit easier to understand and maintain, since `./go test` now runs all of the backend, browser, and end-to-end tests, optionally with coverage enabled. Each of the backend, browser, and end-to-end test suites have been split into their own separate scripts, with the backend and browser tests using a common `scripts/lib/coverage` module.

Previously `./go test` defaulted to running the backend tests, included the browser tests when run with `--coverage`, and didn't run the end-to-end tests at all.