### PR TITLE
Rename `./go test server`, move tests, improve `./go setup` and `./go test`

### DIFF
--- a/go
+++ b/go
@@ -32,6 +32,10 @@ fi
 
 export PATH="node_modules/.bin:$PATH"
 
+if [[ -t 1 || -n "$TRAVIS" ]]; then
+  _GO_LOG_FORMATTING='true'
+fi
+
 . "$_GO_USE_MODULES" 'log'
 
 if [[ ! -d "$_GO_ROOTDIR/node_modules" ]]; then

--- a/scripts/setup
+++ b/scripts/setup
@@ -16,21 +16,31 @@ urlp.install_required_tools() {
 }
 
 urlp.setup() {
-  @go.critical_section_begin
+  local result='0'
 
   export PATH="node_modules/.bin:$PATH"
-  export MOCHA_COLORS='true'
   export FORCE_COLOR='true'
 
+  @go.critical_section_begin
+  @go.log START 'Setting up project...'
   urlp.check_for_prerequisite_tools
 
   if [[ ! -d "$_GO_ROOTDIR/node_modules" ]]; then
     @go.log_command npm install
   fi
   urlp.install_required_tools
-  @go.log_command @go lint
-  @go.log_command @go test --coverage
   @go.critical_section_end
+
+  if ! @go.log_command @go lint; then
+    result='1'
+  fi
+  if ! @go.log_command @go test --coverage; then
+    result='1'
+  fi
+
+  if [[ "$result" -eq '0' ]]; then
+    @go.log FINISH 'Project setup completed successfully.'
+  fi
 }
 
 urlp.setup "$@"

--- a/scripts/test
+++ b/scripts/test
@@ -24,7 +24,8 @@ _test_tab_completion() {
 
 _test() {
   local coverage_run
-  local result
+  local flags=()
+  local result='0'
 
   case "$1" in
   --complete)
@@ -35,23 +36,16 @@ _test() {
     ;;
   --coverage)
     coverage_run='true'
+    flags=('--coverage')
     . "$_GO_USE_MODULES" 'coverage'
     ;;
   esac
 
   export __TEST_ALL='true'
 
-  if [[ "$1" == '--coverage' ]]; then
-    @go test backend --coverage && @go test browser --coverage
-  else
-    @go test backend && @go test browser
-  fi
-
-  result="$?"
-
-  if [[ "$result" -eq '0' ]]; then
-    @go test end-to-end
-    result="$?"
+  if ! @go test server "${flags[@]}" || ! @go test browser "${flags[@]}" ||
+    ! @go test end-to-end; then
+    result='1'
   fi
 
   if [[ -n "$coverage_run" ]] && ! urlp.generate_coverage_report; then

--- a/scripts/test
+++ b/scripts/test
@@ -38,18 +38,37 @@ _test() {
     coverage_run='true'
     flags=('--coverage')
     . "$_GO_USE_MODULES" 'coverage'
+    shift
     ;;
   esac
 
-  export __TEST_ALL='true'
-
-  if ! @go test server "${flags[@]}" || ! @go test browser "${flags[@]}" ||
-    ! @go test end-to-end; then
-    result='1'
+  if [[ "$#" -ne '0' ]]; then
+    @go.printf 'Unknown argument%s: %s\n' "${2:+s}" "$*" >&2
+    return 1
   fi
 
+  export __TEST_ALL='true'
+  export MOCHA_COLORS='true'
+  export FORCE_COLOR='true'
+
+  @go.log START 'Running all automated tests...'
+
+  if ! @go.log_command @go test server "${flags[@]}"; then
+    result='1'
+  fi
+  if ! @go.log_command @go test browser "${flags[@]}"; then
+    result='1'
+  fi
+  if ! @go.log_command @go test end-to-end; then
+    result='1'
+  fi
   if [[ -n "$coverage_run" ]] && ! urlp.generate_coverage_report; then
     result='1'
+  fi
+  if [[ "$result" -eq '0' ]]; then
+    @go.log FINISH 'All automated tests finished successfully.'
+  else
+    @go.log ERROR 'One or more of the tests failed; see results above.'
   fi
   return "$result"
 }

--- a/scripts/test.d/end-to-end
+++ b/scripts/test.d/end-to-end
@@ -30,7 +30,7 @@ _test_end_to_end() {
       "available Node.js version is $node_version. Skipping..."$'\n' >&2
     return
   fi
-  mocha tests/end-to-end.js
+  mocha tests/end-to-end/end-to-end.js
 }
 
 _test_end_to_end "$@"

--- a/scripts/test.d/server
+++ b/scripts/test.d/server
@@ -1,6 +1,6 @@
 #! /bin/bash
 # 
-# Run automated backend tests
+# Run automated server tests
 #
 # Usage:
 #   {{go}} {{cmd}} [--coverage|--edit|--list|--mocha-help] [<glob>...]
@@ -14,15 +14,15 @@
 # In addition to the above option flags, all underlying mocha flags are
 # available.
 #
-# Without <glob> arguments, runs (or edits, or lists) all backend tests from
-# 'tests/'. With one or more <glob> arguments, only runs tests matching
-# 'tests/<glob>-test.js'.
+# Without <glob> arguments, runs (or edits, or lists) all server tests from
+# 'tests/server/'. With one or more <glob> arguments, only runs tests matching
+# 'tests/server/<glob>-test.js'.
 #
 # The '--coverage' flag will place its output in a directory called 'coverage'.
 # An HTML report will be available at 'coverage/lcov-report/index.html'.
 
 declare -r __GO_TEST_FLAGS=('--coverage' '--edit' '--list' '--mocha-help')
-declare -r __GO_TEST_GLOB_ARGS=('tests' '-test.js')
+declare -r __GO_TEST_GLOB_ARGS=('tests/server' '-test.js')
 declare -r __GO_MOCHA_FLAGS_WITH_ARGS=(
   '-O' '--reporter-options'
   '-R' '--reporter'

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var fs = require('fs')
-var helpers = require('./helpers')
+var helpers = require('../helpers')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
 var test = require('selenium-webdriver/testing')

--- a/tests/server/app-test.js
+++ b/tests/server/app-test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-var appLib = require('../lib')
+var appLib = require('../../lib')
 var assembleApp = appLib.assembleApp
 var sessionParams = appLib.sessionParams
-var Config = require('../lib/config')
-var RedirectDb = require('../lib/redirect-db')
+var Config = require('../../lib/config')
+var RedirectDb = require('../../lib/redirect-db')
 var express = require('express')
 var request = require('supertest')
 var chai = require('chai')

--- a/tests/server/auth-test.js
+++ b/tests/server/auth-test.js
@@ -1,9 +1,9 @@
 'use strict'
 
-var auth = require('../lib/auth')
-var testAuth = require('../lib/auth/test')
-var googleAuth = require('../lib/auth/google')
-var RedirectDb = require('../lib/redirect-db')
+var auth = require('../../lib/auth')
+var testAuth = require('../../lib/auth/test')
+var googleAuth = require('../../lib/auth/google')
+var RedirectDb = require('../../lib/redirect-db')
 
 var sinon = require('sinon')
 var chai = require('chai')

--- a/tests/server/config-test.js
+++ b/tests/server/config-test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-var Config = require('../lib/config')
-var helpers = require('./helpers')
+var Config = require('../../lib/config')
+var helpers = require('../helpers')
 var path = require('path')
 
 var sinon = require('sinon')
@@ -9,7 +9,8 @@ var chai = require('chai')
 var expect = chai.expect
 chai.should()
 
-var TEST_CONFIG_PATH = path.join(__dirname, 'helpers', 'test-config.json')
+var TEST_CONFIG_PATH = path.join(
+  path.dirname(__dirname), 'helpers', 'test-config.json')
 
 describe('config', function() {
   var envVarsToRestore, envVarsToDelete, setEnvVar

--- a/tests/server/redirect-db-test.js
+++ b/tests/server/redirect-db-test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-var RedirectDb = require('../lib/redirect-db')
-var RedisClient = require('../lib/redis-client')
+var RedirectDb = require('../../lib/redirect-db')
+var RedisClient = require('../../lib/redis-client')
 
 var sinon = require('sinon')
 var chai = require('chai')

--- a/tests/server/redis-client-test.js
+++ b/tests/server/redis-client-test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-var RedisClient = require('../lib/redis-client')
-var helpers = require('./helpers')
+var RedisClient = require('../../lib/redis-client')
+var helpers = require('../helpers')
 var redis = require('redis')
 var sinon = require('sinon')
 var chai = require('chai')

--- a/tests/server/smoke-test.js
+++ b/tests/server/smoke-test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var path = require('path')
-var helpers = require('./helpers')
+var helpers = require('../helpers')
 var chai = require('chai')
 var chaiAsPromised = require('chai-as-promised')
 
@@ -9,7 +9,8 @@ chai.should()
 chai.use(chaiAsPromised)
 
 describe('Smoke test', function() {
-  var testConfig = path.join(__dirname, 'helpers', 'system-test-config.json'),
+  var testConfig = path.join(
+        path.dirname(__dirname), 'helpers', 'system-test-config.json'),
       doLaunch,
       serverInfo
 


### PR DESCRIPTION
The structure and scope of the tests and their accompanying scripts are now easier to follow. `scripts/test` is more streamlined and robust. `./go lint` and `./go test` are out of the
critical section of `./go setup`, and logging across both `./go setup` and `./go test` is much improved.