### PR TITLE
app: Add unit test for result link focus

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -210,8 +210,6 @@
         result.innerHTML = resultData.message
         return urlp.flashElement(resultFlash, result.outerHTML)
           .then(function() {
-            // TODO(mbland): Add a unit test for this (currently covered by
-            // tests/end-to-end.js).
             var link = resultFlash.getElementsByTagName('A')[0]
             if (link) {
               link.focus()


### PR DESCRIPTION
Per the TODO added in #47 and removed in this commit. The behavior was already covered by the end-to-end test, but still needed a unit test.