### PR TITLE
Generate live browser test coverage report

### DIFF
--- a/public/tests/index.html
+++ b/public/tests/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="vendor/mocha.css" />
+    <style type="text/css" media="all">#coverage{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;margin:60px 50px;}#coverage ul{list-style:none;}</style>
   </head>
   <body>
     <div id="mocha"></div>
@@ -28,5 +29,11 @@
       mocha.checkLeaks();
       mocha.run()
     </script>
+    <div id="coverage" >
+      <ul>
+        <li><a href="/coverage">View coverage report</a></li>
+        <li><a href="/coverage/download">Download coverage report</a></li>
+      </ul>
+    </div>
   </body>
 </html>

--- a/public/tests/lib.js
+++ b/public/tests/lib.js
@@ -29,8 +29,23 @@
 
 before(function() {
   return window.urlpTest.createFixture()
+    .then(function() {
+      return urlp.xhr('POST', '/coverage/reset')
+        .catch(function(err) {
+          console.log('failed to clear coverage data: ' + (err.message || err))
+        })
+    })
 })
 
 beforeEach(function() {
-  window.urlpTest.resetFixture()
+  return window.urlpTest.resetFixture()
+})
+
+after(function() {
+  if (window.__coverage__) {
+    return urlp.xhr('POST', '/coverage/client', window.__coverage__)
+      .catch(function(err) {
+        console.log('failed to post coverage data: ' + (err.message || err))
+      })
+  }
 })

--- a/scripts/serve
+++ b/scripts/serve
@@ -38,7 +38,8 @@ urlp.serve() {
     return
     ;;
   --test)
-    live-server public/
+    live-server \
+      --middleware="$_GO_ROOTDIR/tests/helpers/coverage-middleware.js" public/
     return
     ;;
   esac

--- a/tests/helpers/coverage-middleware.js
+++ b/tests/helpers/coverage-middleware.js
@@ -8,13 +8,12 @@ var rootDir = path.dirname(path.dirname(__dirname))
 istanbulMiddleware.hookLoader(rootDir)
 
 module.exports = istanbulMiddleware.createClientHandler(rootDir, {
+  matcher(req) {
+    return /\.js$/.test(req.url) &&
+      ! (/\/(vendor|generated)\//.test(req.url) || /\.min\.js$/.test(req.url))
+  },
   pathTransformer(req) {
     var pathname = url.parse(req.url).pathname.substring(1)
-
-    if (/\/(vendor|generated)\//.test(pathname) ||
-        /\.min\.js$/.test(pathname)) {
-      return null
-    }
     return path.resolve(rootDir, 'public', pathname)
   }
 })

--- a/tests/helpers/coverage-middleware.js
+++ b/tests/helpers/coverage-middleware.js
@@ -1,5 +1,7 @@
 'use strict'
 
+var express = require('express')
+var app = express()
 var istanbulMiddleware = require('istanbul-middleware')
 var path = require('path')
 var url = require('url')
@@ -7,7 +9,9 @@ var rootDir = path.dirname(path.dirname(__dirname))
 
 istanbulMiddleware.hookLoader(rootDir)
 
-module.exports = istanbulMiddleware.createClientHandler(rootDir, {
+app.use('/coverage', istanbulMiddleware.createHandler())
+
+app.use('/', istanbulMiddleware.createClientHandler(rootDir, {
   matcher(req) {
     return /\.js$/.test(req.url) &&
       ! (/\/(vendor|generated)\//.test(req.url) || /\.min\.js$/.test(req.url))
@@ -16,4 +20,6 @@ module.exports = istanbulMiddleware.createClientHandler(rootDir, {
     var pathname = url.parse(req.url).pathname.substring(1)
     return path.resolve(rootDir, 'public', pathname)
   }
-})
+}))
+
+module.exports = app


### PR DESCRIPTION
Turns out it's really easy to do this with istanbul-middleware, and super convenient and cool!

Also extracted a separate matcher function for istanbul-middleware. Doesn't make a functional difference, but better follows the API.