### PR TITLE
Updates to ensure smooth setup on Linux

### DIFF
--- a/.config/karma.conf.js
+++ b/.config/karma.conf.js
@@ -39,7 +39,15 @@ module.exports = function(config) {
     // When not running under CI, `browsers` will actually get set by
     // karma-detect-browsers.
     browsers: [],
-    detectBrowsers: {},
+    detectBrowsers: {
+      // Work around karma-detect-browsers adding multiple Firefox builds.
+      postDetection(browsers) {
+        if (process.platform !== 'linux') {
+          return browsers
+        }
+        return browsers.filter(b => !b.startsWith('Firefox') || b === 'Firefox')
+      }
+    },
 
     plugins: [ 'karma-*' ],
 

--- a/scripts/lib/coverage
+++ b/scripts/lib/coverage
@@ -17,6 +17,8 @@ urlp.generate_coverage_report() {
 
   if [[ -n "$CI" ]]; then
     urlp.send_coverage_report
+  elif command -v xdg-open >/dev/null; then
+    xdg-open "$report_path"
   elif command -v open >/dev/null; then
     open "$report_path"
   fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -4,7 +4,10 @@
 
 urlp.check_for_prerequisite_tools() {
   if ! command -v node >/dev/null; then
-    printf 'Please install Node.js before continuing.\n' >&2
+    @go.printf 'Please install Node.js before continuing.\n' >&2
+    return 1
+  elif ! command -v redis-server >/dev/null; then
+    @go.printf 'Please install redis-server before continuing.\n' >&2
     return 1
   fi
 }


### PR DESCRIPTION
Fixes `./go test --coverage` and updates the Karma config on Linux, and checks for `redis-server` as a `./go setup` prerequisite.