### PR TITLE
go, test browser: Move MSYS2 POSIX path setting

### DIFF
--- a/go
+++ b/go
@@ -32,13 +32,6 @@ fi
 
 export PATH="node_modules/.bin:$PATH"
 
-# Keep this until the following is resolved:
-# https://github.com/mbland/go-script-bash/issues/176
-if [[ "$OSTYPE" == 'msys' ]]; then
-  export MSYS_NO_PATHCONV='true'
-  export MSYS2_ARG_CONV_EXCL='*'
-fi
-
 if [[ -t 1 || -n "$TRAVIS" ]]; then
   _GO_LOG_FORMATTING='true'
 fi

--- a/scripts/test.d/browser
+++ b/scripts/test.d/browser
@@ -47,6 +47,12 @@ _test_browser_run_tests() {
   if ! _test_browser_create_bundle; then
     return 1
   fi
+
+  if [[ "$OSTYPE" == 'msys' ]]; then
+    export MSYS_NO_PATHCONV='true'
+    export MSYS2_ARG_CONV_EXCL='*'
+  fi
+
   if [[ "$__single_run" == 'true' ]]; then
     _test_browser_run_in_phantomjs
   else


### PR DESCRIPTION
Turns out setting `MSYS_NO_PATHCONV='true'` and `MSYS2_ARG_CONV_EXCL='*'` at the top level was a bad idea, as it breaks `npm install`. So mbland/go-script-bash#176 should be closed.