### PR TITLE
karma: Remove KARMA_SINGLE_RUN, add KARMA_BROWSERS

### DIFF
--- a/.config/karma.conf.js
+++ b/.config/karma.conf.js
@@ -51,15 +51,18 @@ module.exports = function(config) {
 
     plugins: [ 'karma-*' ],
 
-    singleRun: process.env.KARMA_SINGLE_RUN === 'true',
-
     concurrency: Infinity
   }
 
   if (process.env.CI === 'true') {
     options.autoWatch = false
     options.singleRun = true
-    options.browsers.push('Chrome', 'Firefox')
+    options.browsers = [ 'Chrome', 'Firefox' ]
+    options.detectBrowsers.enabled = false
+  }
+
+  if (process.env.KARMA_BROWSERS !== undefined) {
+    options.browsers = process.env.KARMA_BROWSERS.split(',')
     options.detectBrowsers.enabled = false
   }
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -36,7 +36,7 @@ urlp.setup_windows() {
   if ! @go.log_command @go lint; then
     result='1'
   fi
-  if ! KARMA_SINGLE_RUN='true' @go.log_command karma start; then
+  if ! @go.log_command karma start --single-run; then
     result='1'
   fi
   return "$result"

--- a/scripts/test
+++ b/scripts/test
@@ -50,7 +50,6 @@ _test() {
   export __TEST_ALL='true'
   export MOCHA_COLORS='true'
   export FORCE_COLOR='true'
-  export KARMA_SINGLE_RUN='true'
 
   @go.log START 'Running all automated tests...'
 
@@ -61,7 +60,7 @@ _test() {
     result='1'
   fi
   if [[ "$CI" != 'true' ]] && command -v karma >/dev/null &&
-    ! @go.log_command karma start; then
+    ! @go.log_command karma start --single-run; then
     result='1'
   fi
   if ! @go.log_command @go test end-to-end; then


### PR DESCRIPTION
Turns out the `karma start --single-run` flag was there all along.

`KARMA_BROWSERS` is handy for limiting the number of browsers open at once, in case you want or need to do so.