### PR TITLE
Resolve `./go test browser --single-run` issues on Windows Subsystem for Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 coverage/
 dump.rdb
 node_modules/
+npm.log
 public/tests/generated/
 screenshot.png
 scripts/go-script-bash/

--- a/scripts/lib/coverage
+++ b/scripts/lib/coverage
@@ -5,9 +5,10 @@
 export URLP_COVERAGE_DATADIR="${URLP_COVERAGE_DATADIR:-$_GO_ROOTDIR/.coverage}"
 
 urlp.generate_coverage_report() {
-  local report_path="${_GO_ROOTDIR}/coverage/lcov-report/index.html"
+  local report_dir="${_GO_ROOTDIR}/coverage/lcov-report"
+  local report_path="$report_dir/index.html"
 
-  rm -f "$report_path"
+  rm -rf "$report_dir"
 
   if ! istanbul report --root "$URLP_COVERAGE_DATADIR" --include '*.json'; then
     @go.printf 'Failed to generate coverage report.\n' >&2
@@ -17,6 +18,10 @@ urlp.generate_coverage_report() {
 
   if [[ -n "$CI" ]]; then
     urlp.send_coverage_report
+  elif [[ "$COVERAGE_REPORT_SERVER" == 'false' ]]; then
+    return
+  elif [[ "$COVERAGE_REPORT_SERVER" == 'true' ]]; then
+    live-server "$report_dir"
   elif command -v xdg-open >/dev/null; then
     xdg-open "$report_path"
   elif command -v open >/dev/null; then

--- a/scripts/setup
+++ b/scripts/setup
@@ -62,6 +62,7 @@ urlp.setup() {
 
   export PATH="node_modules/.bin:$PATH"
   export FORCE_COLOR='true'
+  export COVERAGE_REPORT_SERVER='false'
 
   @go.critical_section_begin
   @go.log START 'Setting up project...'

--- a/scripts/test.d/browser
+++ b/scripts/test.d/browser
@@ -84,8 +84,7 @@ _test_browser_run_in_phantomjs() {
   test_server_url="http://localhost:${port}"
 
   set -m
-  live-server --no-browser --port=${port} \
-    --middleware="$TEST_BROWSER_COVERAGE_MIDDLEWARE" public/ &
+  "$_GO_ROOTDIR/tests/helpers/coverage-server" "$port" &
 
   if [[ "$?" -ne '0' ]]; then
     @go.printf 'Failed to launch live-server on port %d.\n' "$port" >&2

--- a/tests/helpers/coverage-server
+++ b/tests/helpers/coverage-server
@@ -1,0 +1,12 @@
+#! /usr/bin/env node
+'use strict'
+
+var path = require('path')
+var express = require('express')
+var app = express()
+var port = process.argv[2]
+
+app.use(require('./coverage-middleware'))
+app.use(express.static(path.resolve(__dirname, '../../public')))
+app.listen(port)
+console.log('coverage server listening on port', port)


### PR DESCRIPTION
On Windows Subsystem for Linux, PhantomJS appears to crash when using `live-server`. As widely reported, the same thing happens with Karma, which can be observed by trying to run Karma in this project. It seems to be related to JavaScript that attempts to force a browser reload (possibly because of WebSockets, perhaps?).

This change resolves the issue for `./go test browser --single-run` by supplying a small, hand-written test server instead.

Also adds the `COVERAGE_REPORT_SERVER` environment variable. By setting this environment variable to `false`, the script won't open a browser window after coverage collection. With it set to `true`, it will open it using `live-server`, which is preferable to opening it with xdg-open on Windows Subsystem for Linux. When it's empty (and `CI` isn't set), it will attempt to open the report directly using `xdg-open` (Linux) or `open` (macOS).

Also, `npm.log` (generated by `./go setup`) is added to `.gitignore`.