### PR TITLE
test: Add .config/env.local, disable Karma on WSL

### DIFF
--- a/.config/env.local
+++ b/.config/env.local
@@ -1,0 +1,69 @@
+#! /usr/bin/env bash
+#
+# Environment variables for local project configuration
+#
+# Uncomment and modify these as necessary to configure your workspace based on
+# your system. At a minimum, you may wish to set SELENIUM_BROWSER, and possibly
+# KARMA_BROWSERS.
+#
+# Except for the `*_BIN` variables, all of these may be overridden using command
+# line prefix assignments, e.g.:
+#
+#  $ SELENIUM_BROWSER=safari ./go test end-to-end
+#
+# Special notes for Windows Subsystem for Linux
+# ---------------------------------------------
+# PhantomJS currently doesn't work with Karma or live-server, likely due to a
+# websockets issue:
+#
+# - https://github.com/karma-runner/karma-phantomjs-launcher/issues/124
+# - https://github.com/Microsoft/BashOnWindows/issues/903
+#
+# The binary packaged with the edge-launcher npm also doesn't currently work
+# with Windows Subsystem for Linux, so Edge should not be specified in this
+# environment either.
+#
+# In fact, Karma shouldn't be used at all with Windows Subsystem for Linux
+# currently, as none of the launchers launch the browsers properly even when the
+# `*_BIN` paths are correctly defined. (This is likely due to the fact that the
+# Windows programs can't process the Window Subsystem for Linux current
+# directory and file paths.)
+
+# When COVERAGE_REPORTS_SERVER is 'false', the `./go test --coverage` (and
+# related commands) won't open a browser window after coverage collection. With
+# it set to 'true', it will open it using `live-server`, which is preferable to
+# opening it with `xdg-open` on Windows Subsystem for Linux. When it's empty
+# (and `CI` isn't set), it will attempt to open the report directly using
+# `xdg-open` (Linux) or `open` (macOS).
+#
+#export COVERAGE_REPORT_SERVER="${COVERAGE_REPORT_SERVER:-true}"
+
+# Defines the browser used with `./go test end-to-end`. By default this will be
+# Google Chrome. If you do not have Google Chrome installed on your system,
+# you'll need to set this differently.
+#
+# For more information, see: https://www.npmjs.com/package/selenium-webdriver
+#
+#export SELENIUM_BROWSER="${SELENIUM_BROWSER:-phantomjs}"
+
+# Defines the browsers that Karma should use. For available browsers, see:
+#
+# - node_modules/karma-detect-browsers/browsers/index.js
+#
+# You may wish to source this file directly to set KARMA_BROWSERS before running
+# `karma` directly.
+#
+#export KARMA_BROWSERS="${KARMA_BROWSERS:-Chrome,Firefox,IE,Edge}"
+
+# The following define environment variables used by karma-detect-browsers and
+# the karma-*-launcher packages.
+#
+#export CHROME_BIN=''
+#export CHROME_CANARY_BIN=''
+#export EDGE_BIN=''
+#export FIREFOX_BIN=''
+#export FIREFOX_NIGHTLY_BIN=''
+#export IE_BIN=''
+#export OPERA_BIN=''
+#export SAFARI_BIN=''
+#export SAFARI_TECH_PREVIEW_BIN=''

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Are your editor's temp files, OS metadata files, etc. showing up in `git
 # status`? Try adding them to `$HOME/.config/git/ignore` instead.
+.config/env.local
 .coverage/
 coverage/
 dump.rdb

--- a/go
+++ b/go
@@ -37,6 +37,7 @@ if [[ -t 1 || -n "$TRAVIS" ]]; then
 fi
 
 . "$_GO_USE_MODULES" 'log'
+. "$_GO_ROOTDIR/.config/env.local"
 
 if [[ ! -d "$_GO_ROOTDIR/node_modules" ]]; then
   @go.setup_project 'setup'

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "codeclimate-test-reporter": "^0.4.1",
     "coveralls": "^2.13.1",
     "eslint": "^3.19.0",
+    "is-wsl": "^1.1.0",
     "istanbul": "^0.4.5",
     "istanbul-middleware": "^0.2.2",
     "live-server": "^1.2.0",

--- a/scripts/lib/karma
+++ b/scripts/lib/karma
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+#
+# Disables Karma for continuous integration and Windows Subsystem for Linux runs
+
+if [[ -z "$DISABLE_KARMA" && -n "$CI" ]] ||
+  node -e "process.exit(require('is-wsl') ? 0 : 1)"; then
+  export DISABLE_KARMA='true'
+fi

--- a/scripts/setup
+++ b/scripts/setup
@@ -2,7 +2,7 @@
 #
 # Runs first-time setup commands for a freshly-cloned repository
 
-. "$_GO_USE_MODULES" 'setup'
+. "$_GO_USE_MODULES" 'setup' 'karma'
 
 urlp.check_for_prerequisite_tools() {
   if ! command -v node >/dev/null; then
@@ -21,7 +21,7 @@ urlp.install_required_tools() {
 }
 
 urlp.install_optional_tools() {
-  if [[ "$CI" != 'true' ]] && command -v karma >/dev/null; then
+  if [[ "$DISABLE_KARMA" != 'true' ]] && command -v karma >/dev/null; then
     @go.log_command @go setup karma
   fi
 }

--- a/scripts/test
+++ b/scripts/test
@@ -11,6 +11,8 @@
 # The '--coverage' flag will place its output in a directory called 'coverage'.
 # An HTML report will be available at 'coverage/lcov-report/index.html'.
 
+. "$_GO_USE_MODULES" 'karma'
+
 _test_tab_completion() {
   local word_index="$1"
   shift
@@ -59,7 +61,7 @@ _test() {
   if ! @go.log_command @go test browser "${flags[@]}"; then
     result='1'
   fi
-  if [[ "$CI" != 'true' ]] && command -v karma >/dev/null &&
+  if [[ "$DISABLE_KARMA" != 'true' ]] && command -v karma >/dev/null &&
     ! @go.log_command karma start --single-run; then
     result='1'
   fi


### PR DESCRIPTION
`.config/env.local` enables relatively easy local configuration, and is listed in `.gitignore` to avoid committing local modifications.

Also, Karma is disabled completely on Windows Subsystem for Linux for the reasons described in the `.config/env.local` header comments.