### PR TITLE
Move .config/env.local to .config/env.template

### DIFF
--- a/.config/env.template
+++ b/.config/env.template
@@ -2,17 +2,31 @@
 #
 # Environment variables for local project configuration
 #
-# Uncomment and modify these as necessary to configure your workspace based on
-# your system. At a minimum, you may wish to set SELENIUM_BROWSER, and possibly
-# KARMA_BROWSERS.
+# If desired, copy this file to .config/env.local and modify these variables as
+# necessary to configure your workspace based on your system. At a minimum, you
+# may wish to set SELENIUM_BROWSER, and possibly KARMA_BROWSERS.
 #
+# The ./go script will source .config/env.local automatically if it exists.
+# You're free to include any other environment variables in .config/env.local
+# that you wish; this template contains only those used directly by project
+# scripts and components.
+#
+# Command-line overrides
+# ----------------------
 # Except for the `*_BIN` variables, all of these may be overridden using command
 # line prefix assignments, e.g.:
 #
 #  $ SELENIUM_BROWSER=safari ./go test end-to-end
 #
-# Special notes for Windows Subsystem for Linux
-# ---------------------------------------------
+# Running Karma
+# -------------
+# You may wish to source this file directly to set KARMA_BROWSERS before running
+# `karma start`, or override it on the command line, e.g.:
+#
+# $ KARMA_BROWSERS='Chrome,Firefox' karma start
+#
+# Windows Subsystem for Linux issues
+# ----------------------------------
 # PhantomJS currently doesn't work with Karma or live-server, likely due to a
 # websockets issue:
 #
@@ -35,35 +49,32 @@
 # opening it with `xdg-open` on Windows Subsystem for Linux. When it's empty
 # (and `CI` isn't set), it will attempt to open the report directly using
 # `xdg-open` (Linux) or `open` (macOS).
-#
-#export COVERAGE_REPORT_SERVER="${COVERAGE_REPORT_SERVER:-true}"
 
-# Defines the browser used with `./go test end-to-end`. By default this will be
-# Google Chrome. If you do not have Google Chrome installed on your system,
-# you'll need to set this differently.
+export COVERAGE_REPORT_SERVER="${COVERAGE_REPORT_SERVER:-true}"
+
+# Defines the browser used with `./go test end-to-end`. By default the
+# selenium-webdriver package will use Google Chrome. If you do not have Google
+# Chrome installed on your system, you'll need to set this differently.
 #
 # For more information, see: https://www.npmjs.com/package/selenium-webdriver
-#
-#export SELENIUM_BROWSER="${SELENIUM_BROWSER:-phantomjs}"
+
+export SELENIUM_BROWSER="${SELENIUM_BROWSER:-phantomjs}"
 
 # Defines the browsers that Karma should use. For available browsers, see:
 #
 # - node_modules/karma-detect-browsers/browsers/index.js
-#
-# You may wish to source this file directly to set KARMA_BROWSERS before running
-# `karma` directly.
-#
-#export KARMA_BROWSERS="${KARMA_BROWSERS:-Chrome,Firefox,IE,Edge}"
+
+export KARMA_BROWSERS="${KARMA_BROWSERS:-Chrome,Firefox,IE,Edge}"
 
 # The following define environment variables used by karma-detect-browsers and
 # the karma-*-launcher packages.
-#
-#export CHROME_BIN=''
-#export CHROME_CANARY_BIN=''
-#export EDGE_BIN=''
-#export FIREFOX_BIN=''
-#export FIREFOX_NIGHTLY_BIN=''
-#export IE_BIN=''
-#export OPERA_BIN=''
-#export SAFARI_BIN=''
-#export SAFARI_TECH_PREVIEW_BIN=''
+
+export CHROME_BIN=''
+export CHROME_CANARY_BIN=''
+export EDGE_BIN=''
+export FIREFOX_BIN=''
+export FIREFOX_NIGHTLY_BIN=''
+export IE_BIN=''
+export OPERA_BIN=''
+export SAFARI_BIN=''
+export SAFARI_TECH_PREVIEW_BIN=''

--- a/go
+++ b/go
@@ -37,7 +37,10 @@ if [[ -t 1 || -n "$TRAVIS" ]]; then
 fi
 
 . "$_GO_USE_MODULES" 'log'
-. "$_GO_ROOTDIR/.config/env.local"
+
+if [[ -f "$_GO_ROOTDIR/.config/env.local" ]]; then
+  . "$_GO_ROOTDIR/.config/env.local"
+fi
 
 if [[ ! -d "$_GO_ROOTDIR/node_modules" ]]; then
   @go.setup_project 'setup'


### PR DESCRIPTION
The original intention of adding .config/env.local to .gitignore was to prevent local changes to the file from getting checked in. However, .gitignore will not ignore files actually checked into the repository.

With this change, the convention is now to copy .config/env.template to .config/env.local before making changes. `./go` now checks for this file before attempting to source it.