### PR TITLE
test --coverage: Shut down live-server gracefully

### DIFF
--- a/scripts/lib/coverage
+++ b/scripts/lib/coverage
@@ -21,7 +21,10 @@ urlp.generate_coverage_report() {
   elif [[ "$COVERAGE_REPORT_SERVER" == 'false' ]]; then
     return
   elif [[ "$COVERAGE_REPORT_SERVER" == 'true' ]]; then
+    @go.printf 'Opening report with live-server; kill with CTRL-C.\n'
+    trap 'printf "\nClosing live-server...\n"' INT
     live-server "$report_dir"
+    return 0
   elif command -v xdg-open >/dev/null; then
     xdg-open "$report_path"
   elif command -v open >/dev/null; then


### PR DESCRIPTION
`./go test --coverage` serves results via live-server when `COVERAGE_REPORT_SERVER='true'`. Previously, the script would exit with a signal status when the user would enter CTRL-C to terminate the server, regardless of whether the test suite actually passed or failed.

`./go test --coverage` now exits with the correct status when the user terminates the server. It also emits informational messages when live-server is started and terminated.