### PR TITLE
Rename browser-test-server, use middleware if COVERAGE_RUN=true

### DIFF
--- a/scripts/test.d/browser
+++ b/scripts/test.d/browser
@@ -84,7 +84,8 @@ _test_browser_run_in_phantomjs() {
   test_server_url="http://localhost:${port}"
 
   set -m
-  "$_GO_ROOTDIR/tests/helpers/browser-test-server" "$port" &
+  COVERAGE_RUN="$__coverage_run" \
+    "$_GO_ROOTDIR/tests/helpers/browser-test-server" "$port" &
 
   if [[ "$?" -ne '0' ]]; then
     @go.printf 'Failed to launch live-server on port %d.\n' "$port" >&2

--- a/scripts/test.d/browser
+++ b/scripts/test.d/browser
@@ -84,7 +84,7 @@ _test_browser_run_in_phantomjs() {
   test_server_url="http://localhost:${port}"
 
   set -m
-  "$_GO_ROOTDIR/tests/helpers/coverage-server" "$port" &
+  "$_GO_ROOTDIR/tests/helpers/browser-test-server" "$port" &
 
   if [[ "$?" -ne '0' ]]; then
     @go.printf 'Failed to launch live-server on port %d.\n' "$port" >&2

--- a/tests/helpers/browser-test-server
+++ b/tests/helpers/browser-test-server
@@ -6,7 +6,9 @@ var express = require('express')
 var app = express()
 var port = process.argv[2]
 
-app.use(require('./coverage-middleware'))
+if (process.env.COVERAGE_RUN === 'true') {
+  app.use(require('./coverage-middleware'))
+}
 app.use(express.static(path.resolve(__dirname, '../../public')))
 app.listen(port)
 console.log(path.basename(__filename) + ' listening on port', port)

--- a/tests/helpers/browser-test-server
+++ b/tests/helpers/browser-test-server
@@ -9,4 +9,4 @@ var port = process.argv[2]
 app.use(require('./coverage-middleware'))
 app.use(express.static(path.resolve(__dirname, '../../public')))
 app.listen(port)
-console.log('coverage server listening on port', port)
+console.log(path.basename(__filename) + ' listening on port', port)


### PR DESCRIPTION
The test server is used for all `./test browser --single-run` modes, not just when running with `--coverage`.

Also, setting the middleware only when `COVERAGE_RUN=true` doesn't affect output much, since assertion failures via PhantomJS don't produce stack trace output, but still feels better to have this mechanism in place.