### PR TITLE
travis: Set npm version spec to ^5.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
 - "export DISPLAY=:99.0"
 - "sh -e /etc/init.d/xvfb start"
 - "export PATH=$PWD/node_modules/phantomjs-prebuilt/lib/phantom/bin:$PATH"
-- "npm install -g npm"
+- "npm install -g npm@^5.0.1"
 
 script:
 - "./go setup"


### PR DESCRIPTION
Seems a little more correct than a plain `npm install -g npm`.