### PR TITLE
tests: Fix launchRedis for redis-server v4

### DIFF
--- a/tests/helpers/index.js
+++ b/tests/helpers/index.js
@@ -43,7 +43,7 @@ module.exports = exports = {
 
       redisServer.stdout.on('data', data => {
         stdout += data
-        if (stdout.match('The server is now ready to accept connections')) {
+        if (stdout.match('[Rr]eady to accept connections')) {
           resolve({ port: port, server: redisServer })
         }
       })


### PR DESCRIPTION
The "Ready to accept connections" string changed in v4.0.0, breaking the previous `launchRedis` implementation.