### PR TITLE
end-to-end: takeScreenshot takes optional filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ dump.rdb
 node_modules/
 npm.log
 public/tests/generated/
-screenshot.png
+screenshot*.png
 scripts/go-script-bash/
 test-config*.json
 tests/bats/

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -42,11 +42,11 @@ test.describe('End-to-end test', function() {
 
   activeElement = () => driver.switchTo().activeElement()
 
-  takeScreenshot = () => {
+  takeScreenshot = (filename) => {
     driver.takeScreenshot().then(screenshot => {
       return new Promise((resolve, reject) => {
-        fs.writeFile('screenshot.png', screenshot, 'base64',
-          err => err ? reject(err) : resolve())
+        fs.writeFile('screenshot' + (filename ? ('-' + filename) : '') + '.png',
+          screenshot, 'base64', err => err ? reject(err) : resolve())
       })
     })
   }


### PR DESCRIPTION
By default, `takeScreenshot` will write `screenshot.png`. If the `filename` argument is present, it will write `screenshot-<FILENAME>.png`, where `<FILENAME>` is the value of `filename`. This enables multiple screenshots during a single test run—sort of like a graphical `printf` tracing statement.