### PR TITLE
server: Add /id route to get logged-in user ID

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,7 @@ function assembleApp(app, redirectDb, logger, sessionStore, config) {
 
   app.use('/', ensureLoggedIn('/auth'))
   app.use(express.static(path.join(__dirname, '..', 'public')))
+  app.get('/id', (req, res) => res.status(200).send(req.user.id))
   app.use('/api', assembleApiRouter(redirectDb, logger))
 
   app.get('/*', (req, res) => {

--- a/tests/server/app-test.js
+++ b/tests/server/app-test.js
@@ -127,6 +127,13 @@ describe('assembleApp', function() {
         .expect(200, /URL Pointers/)
     })
 
+    it('provides the user ID on /id', function() {
+      return request(app)
+        .get('/id')
+        .set('cookie', sessionCookie)
+        .expect(200, 'mbland@acm.org')
+    })
+
     it('logs out on /logout', function() {
       return request(app)
         .get('/logout')


### PR DESCRIPTION
This will be used to provide a "logged in as" indicator and to retrieve the user's list of URLs.