### PR TITLE
Add logged in user, logout link

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -40,7 +40,14 @@
       js.src = 'vendor/es6-promise.auto.min.js'
       head.appendChild(js)
     }
-    urlp.showView(window.location.hash)
+    urlp.userId = urlp.xhr('GET', '/id')
+      .then(r => r.response)
+      .catch(() => '<unknown user>')
+
+    return urlp.userId.then(id => {
+      document.getElementById('userid').textContent = id
+      urlp.showView(window.location.hash)
+    })
   }
 
   urlp.showView = function(hashId) {

--- a/public/app.js
+++ b/public/app.js
@@ -41,10 +41,10 @@
       head.appendChild(js)
     }
     urlp.userId = urlp.xhr('GET', '/id')
-      .then(r => r.response)
-      .catch(() => '<unknown user>')
+      .then(function(xhr) { return xhr.response })
+      .catch(function() { return '&lt;unknown user&gt;' })
 
-    return urlp.userId.then(id => {
+    return urlp.userId.then(function(id) {
       document.getElementById('userid').textContent = id
       urlp.showView(window.location.hash)
     })

--- a/public/index.html
+++ b/public/index.html
@@ -5,10 +5,14 @@
   <link rel='stylesheet' href='css/vendor/normalize.css'>
   <link rel='stylesheet' href='css/vendor/skeleton-2.0.4.min.css'>
   <script src='app.js'></script>
-  <style type="text/css" media="all">body{margin-top:30px;}.templates{display:none;}.result{padding:5px;border-radius:5px;}.result.success{background-color:whitesmoke;}.result.failure{background-color:lavenderblush;}</style>
+  <style type="text/css" media="all">body{margin-top:30px;}.templates{display:none;}.login{text-align:right;}.result{padding:5px;border-radius:5px;}.result.success{background-color:whitesmoke;}.result.failure{background-color:lavenderblush;}</style>
 </head>
 <body>
   <div class='markup'>
+    <div class='login container'>
+      <span id='userid'></span> |
+      <a href='/logout'>Log out</a>
+    </div>
     <div class='view-container container'>
     </div>
     <div class='templates'>

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -100,7 +100,7 @@ describe('URL Pointers', function() {
     })
 
     it('subscribes to the hashchange event', function() {
-      return invokeLoadApp().then(hashChangeHandler => {
+      return invokeLoadApp().then(function(hashChangeHandler) {
         expect(typeof hashChangeHandler).to.equal('function')
         spyOn('showView')
         hashChangeHandler()
@@ -109,7 +109,7 @@ describe('URL Pointers', function() {
     })
 
     it('shows the logged in/logout block', function() {
-      return invokeLoadApp().then(() => {
+      return invokeLoadApp().then(function() {
         var loginBlock,
             userId,
             logout
@@ -131,9 +131,9 @@ describe('URL Pointers', function() {
     it('shows an unknown user marker on /id error', function() {
       urlp.xhr.withArgs('GET', '/id').returns(
         Promise.reject({ status: 404, response: 'forced error' }))
-      return invokeLoadApp().then(() => {
+      return invokeLoadApp().then(function() {
         document.getElementById('userid').textContent
-          .should.equal('<unknown user>')
+          .should.equal('&lt;unknown user&gt;')
       })
     })
   })

--- a/public/tests/tests.js
+++ b/public/tests/tests.js
@@ -10,6 +10,10 @@ describe('URL Pointers', function() {
       doubles = [],
       REDIRECT_LOCATION = 'https://mike-bland.com/'
 
+  beforeEach(function() {
+    stubOut('xhr')
+  })
+
   afterEach(function() {
     doubles.forEach(function(double) {
       double.restore()
@@ -73,28 +77,64 @@ describe('URL Pointers', function() {
   describe('loadApp', function() {
     var invokeLoadApp
 
-    invokeLoadApp = function() {
-      var origHashChangeHandler = window.onhashchange,
-          newHashChangeHandler
+    beforeEach(function() {
+      urlp.xhr.withArgs('GET', '/id').returns(
+        Promise.resolve({ response: 'mbland@acm.org' }))
+    })
 
-      urlp.loadApp()
-      newHashChangeHandler = window.onhashchange
-      window.onhashchange = origHashChangeHandler
-      return newHashChangeHandler
+    invokeLoadApp = function() {
+      var origHashChangeHandler = window.onhashchange
+
+      return urlp.loadApp().then(function() {
+        var newHashChangeHandler = window.onhashchange
+        window.onhashchange = origHashChangeHandler
+        return newHashChangeHandler
+      })
     }
 
     it('invokes the router when loaded', function() {
       spyOn('showView')
-      invokeLoadApp()
-      urlp.showView.calledWith(window.location.hash).should.be.true
+      return invokeLoadApp().then(function() {
+        urlp.showView.calledWith(window.location.hash).should.be.true
+      })
     })
 
     it('subscribes to the hashchange event', function() {
-      var hashChangeHandler = invokeLoadApp()
-      expect(typeof hashChangeHandler).to.equal('function')
-      spyOn('showView')
-      hashChangeHandler()
-      urlp.showView.calledWith(window.location.hash).should.be.true
+      return invokeLoadApp().then(hashChangeHandler => {
+        expect(typeof hashChangeHandler).to.equal('function')
+        spyOn('showView')
+        hashChangeHandler()
+        urlp.showView.calledWith(window.location.hash).should.be.true
+      })
+    })
+
+    it('shows the logged in/logout block', function() {
+      return invokeLoadApp().then(() => {
+        var loginBlock,
+            userId,
+            logout
+
+        loginBlock = document.getElementsByClassName('login')[0]
+        expect(loginBlock).to.not.be.undefined
+
+        userId = loginBlock.querySelector('[id=userid]')
+        expect(userId).to.not.be.undefined
+        userId.textContent.should.equal('mbland@acm.org')
+
+        logout = loginBlock.getElementsByTagName('A')[0]
+        expect(logout).to.not.be.undefined
+        logout.href.should.equal(
+          window.location.protocol + '//' + window.location.host + '/logout')
+      })
+    })
+
+    it('shows an unknown user marker on /id error', function() {
+      urlp.xhr.withArgs('GET', '/id').returns(
+        Promise.reject({ status: 404, response: 'forced error' }))
+      return invokeLoadApp().then(() => {
+        document.getElementById('userid').textContent
+          .should.equal('<unknown user>')
+      })
     })
   })
 
@@ -277,7 +317,6 @@ describe('URL Pointers', function() {
 
     expectXhr = function() {
       var payload = { location: REDIRECT_LOCATION }
-      stubOut('xhr')
       return urlp.xhr.withArgs('POST', '/api/create/foo', payload)
     }
 
@@ -301,7 +340,6 @@ describe('URL Pointers', function() {
 
     it('strips leading slashes from the link name', function() {
       var payload = { location: REDIRECT_LOCATION }
-      stubOut('xhr')
       urlp.xhr.withArgs('POST', '/api/create/foo', payload)
         .returns(Promise.resolve())
 

--- a/tests/end-to-end/end-to-end.js
+++ b/tests/end-to-end/end-to-end.js
@@ -34,12 +34,9 @@ test.describe('End-to-end test', function() {
   })
 
   test.afterEach(function() {
-    return driver.close()
-      .then(function() {
-        return new Promise(function(resolve, reject) {
-          redisClient.flushdb(err => err ? reject(err) : resolve())
-        })
-      })
+    return new Promise(function(resolve, reject) {
+      redisClient.flushdb(err => err ? reject(err) : resolve())
+    })
   })
 
   test.after(function() {


### PR DESCRIPTION
Required returning a Promise from `urlp.loadApp`, since we're fetching the user ID asynchronously. If network overhead is ever an issue, we can consider rendering index.html as a template, or sending back the logged-in user in an HTTP header.

Also, while experimenting with new end-to-end test cases, I realized that calling `driver.close()` would actually end the Chrome session, so the second commit removes that call from `afterEach`.